### PR TITLE
Use mmap64 instead of mmap

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -21,9 +21,9 @@ pub struct Mmap {
 }
 
 impl Mmap {
-    pub fn new(fd: &Fd, offset: i64, len: usize) -> io::Result<Mmap> {
+    pub fn new(fd: &Fd, offset: libc::off_t, len: usize) -> io::Result<Mmap> {
         unsafe {
-            match libc::mmap64(
+            match libc::mmap(
                 ptr::null_mut(),
                 len,
                 libc::PROT_READ | libc::PROT_WRITE,

--- a/src/util.rs
+++ b/src/util.rs
@@ -23,7 +23,7 @@ pub struct Mmap {
 impl Mmap {
     pub fn new(fd: &Fd, offset: i64, len: usize) -> io::Result<Mmap> {
         unsafe {
-            match libc::mmap(
+            match libc::mmap64(
                 ptr::null_mut(),
                 len,
                 libc::PROT_READ | libc::PROT_WRITE,


### PR DESCRIPTION
Small change to allow building the crate on 32-bit targets.