### PR TITLE
Allow access to the flags value of CQEs

### DIFF
--- a/src/cqueue.rs
+++ b/src/cqueue.rs
@@ -161,4 +161,9 @@ impl Entry {
     pub fn user_data(&self) -> u64 {
         self.0.user_data
     }
+
+    /// Flags
+    pub fn flags(&self) -> u32 {
+        self.0.flags
+    }
 }


### PR DESCRIPTION
Access to the result is already available. The flags value isn't, however. I can't see any reason it shouldn't be - and access to the flags value is necessary to use the buffer selection mechanism.