### PR TITLE
sys: Expose the module as public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 
 #[macro_use]
 mod util;
-mod sys;
+pub mod sys;
 mod register;
 mod submit;
 pub mod squeue;


### PR DESCRIPTION
By making the sys module public, we can let the caller rely on some very
useful constants.

Fixes #33 

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>