### PR TITLE
Add direct-syscall feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           profile: minimal
           override: true
       - uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,13 @@ members = [ "io-uring-test" ]
 concurrent = [ "parking_lot" ]
 unstable = []
 overwrite = [ "bindgen" ]
+direct-syscall = [ "sc" ]
 
 [dependencies]
 libc = "0.2"
 bitflags = "1"
 parking_lot = { version = "0.11", optional = true }
+sc = { version = "0.2", optional = true }
 
 [build-dependencies]
 bindgen = { version = "0.55", optional = true }

--- a/io-uring-test/Cargo.toml
+++ b/io-uring-test/Cargo.toml
@@ -13,3 +13,7 @@ anyhow = "1"
 tempfile = "3"
 once_cell = "1"
 socket2 = "0.3"
+
+[features]
+default = [ "direct-syscall" ]
+direct-syscall = [ "io-uring/direct-syscall" ]

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -60,11 +60,7 @@ pub unsafe fn io_uring_setup(entries: c_uint, p: *mut io_uring_params) -> c_int 
 
 #[cfg(feature = "direct-syscall")]
 pub unsafe fn io_uring_setup(entries: c_uint, p: *mut io_uring_params) -> c_int {
-    sc::syscall2(
-        __NR_io_uring_setup as usize,
-        entries as usize,
-        p as usize,
-    ) as _
+    sc::syscall2(__NR_io_uring_setup as usize, entries as usize, p as usize) as _
 }
 
 #[cfg(not(feature = "direct-syscall"))]


### PR DESCRIPTION
This PR makes `io-uring` crate independent of `libc`.