### PR TITLE
Add push_multiple

### DIFF
--- a/examples/tcp_echo.rs
+++ b/examples/tcp_echo.rs
@@ -40,7 +40,7 @@ impl AcceptCount {
 
     pub fn push_to(&mut self, sq: &mut squeue::AvailableQueue) {
         while self.count > 0 {
-            if !unsafe { sq.push(self.entry) } {
+            if unsafe { sq.push(self.entry) }.is_err() {
                 break;
             }
             self.count -= 1;
@@ -125,7 +125,7 @@ fn main() -> anyhow::Result<()> {
                         .build()
                         .user_data(poll_token as _);
 
-                    if !unsafe { sq.push(poll_e) } {
+                    if unsafe { sq.push(poll_e) }.is_err() {
                         backlog.push(poll_e);
                     }
                 }
@@ -146,7 +146,7 @@ fn main() -> anyhow::Result<()> {
                         .build()
                         .user_data(token_index as _);
 
-                    if !unsafe { sq.push(read_e) } {
+                    if unsafe { sq.push(read_e) }.is_err() {
                         backlog.push(read_e);
                     }
                 }
@@ -175,7 +175,7 @@ fn main() -> anyhow::Result<()> {
                             .build()
                             .user_data(token_index as _);
 
-                        if !unsafe { sq.push(write_e) } {
+                        if unsafe { sq.push(write_e) }.is_err() {
                             backlog.push(write_e);
                         }
                     }
@@ -214,7 +214,7 @@ fn main() -> anyhow::Result<()> {
                             .user_data(token_index as _)
                     };
 
-                    if !unsafe { sq.push(entry) } {
+                    if unsafe { sq.push(entry) }.is_err() {
                         backlog.push(entry);
                     }
                 }

--- a/examples/tcp_echo.rs
+++ b/examples/tcp_echo.rs
@@ -40,12 +40,10 @@ impl AcceptCount {
 
     pub fn push_to(&mut self, sq: &mut squeue::AvailableQueue) {
         while self.count > 0 {
-            unsafe {
-                match sq.push(self.entry.clone()) {
-                    Ok(_) => self.count -= 1,
-                    Err(_) => break,
-                }
+            if !unsafe { sq.push(self.entry) } {
+                break;
             }
+            self.count -= 1;
         }
     }
 }
@@ -127,10 +125,8 @@ fn main() -> anyhow::Result<()> {
                         .build()
                         .user_data(poll_token as _);
 
-                    unsafe {
-                        if let Err(entry) = sq.push(poll_e) {
-                            backlog.push(entry);
-                        }
+                    if !unsafe { sq.push(poll_e) } {
+                        backlog.push(poll_e);
                     }
                 }
                 Token::Poll { fd } => {
@@ -150,10 +146,8 @@ fn main() -> anyhow::Result<()> {
                         .build()
                         .user_data(token_index as _);
 
-                    unsafe {
-                        if let Err(entry) = sq.push(read_e) {
-                            backlog.push(entry);
-                        }
+                    if !unsafe { sq.push(read_e) } {
+                        backlog.push(read_e);
                     }
                 }
                 Token::Read { fd, buf_index } => {
@@ -181,10 +175,8 @@ fn main() -> anyhow::Result<()> {
                             .build()
                             .user_data(token_index as _);
 
-                        unsafe {
-                            if let Err(entry) = sq.push(write_e) {
-                                backlog.push(entry);
-                            }
+                        if !unsafe { sq.push(write_e) } {
+                            backlog.push(write_e);
                         }
                     }
                 }
@@ -222,10 +214,8 @@ fn main() -> anyhow::Result<()> {
                             .user_data(token_index as _)
                     };
 
-                    unsafe {
-                        if let Err(entry) = sq.push(entry) {
-                            backlog.push(entry);
-                        }
+                    if !unsafe { sq.push(entry) } {
+                        backlog.push(entry);
                     }
                 }
             }

--- a/src/squeue.rs
+++ b/src/squeue.rs
@@ -229,20 +229,19 @@ impl AvailableQueue<'_> {
     }
 
     /// Attempts to push an [`Entry`] into the queue.
-    /// If pushing the entry was successful, this function returns `true`. If the queue was full,
-    /// this function returns `false`.
+    /// If the queue is full, this function returns an error.
     ///
     /// # Safety
     ///
     /// Developers must ensure that parameters of the [`Entry`] (such as buffer) are valid and will
     /// be valid for the entire duration of the operation, otherwise it may cause memory problems.
-    pub unsafe fn push(&mut self, Entry(entry): Entry) -> bool {
+    pub unsafe fn push(&mut self, Entry(entry): Entry) -> Result<(), ()> {
         if !self.is_full() {
             *self.queue.sqes.add((self.tail & self.ring_mask) as usize) = entry;
             self.tail = self.tail.wrapping_add(1);
-            true
+            Ok(())
         } else {
-            false
+            Err(())
         }
     }
 }


### PR DESCRIPTION
Currently concurrent io_uring instances can't really be used to send linked SQEs because another thread could call `push` in between one thread calling `push` twice. This PR adds a new function, `push_multiple`, to allow pushing multiple SQEs atomically.

Since it's not easy to pass in an arbitrary number of owned values to a function in Rust yet, I decided that it would be better to make `squeue::Entry` `Copy` so that it wouldn't be inconsistent to take both `Entry` and `&[Entry]`. ~~And since we no longer need to return back ownership of the `Entry` when the queue is full, the push functions return `bool`s instead of `Result<(), Entry>` - although they could also return `Result<(), ()>`.~~ Actually, after further thought I have decided to use `Result<(), ()>` because it has more obvious semantics and it is `#[must_use]`.