### PR TITLE
Add iai bench (with iou and liburing)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,6 +43,9 @@ jobs:
           - x86_64-unknown-linux-gnu
 
     steps:
+      - run: sudo apt-get update
+      - run: sudo apt install -y valgrind
+
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           toolchain: nightly
           profile: minimal
+          components: clippy
           override: true
       - uses: actions-rs/clippy-check@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,33 @@ jobs:
           use-cross: true
           args: --package io-uring-test --target ${{ matrix.target }}
 
+  bench:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --package io-uring-bench
+      - uses: actions-rs/cargo@v1
+        with:
+          command: bench
+          use-cross: true
+          args: --package io-uring-test --bench iai_new_nop
+
   check:
     runs-on: ubuntu-latest
 
@@ -57,10 +84,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --target ${{ matrix.target }} --features unstable
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --package io-uring-bench --target ${{ matrix.target }}
+
 
   fmt:
     name: fmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
           use-cross: true
           args: --package io-uring-test --target ${{ matrix.target }}
 
-  bench:
+  check-bench:
     runs-on: ubuntu-latest
 
     strategy:
@@ -43,9 +43,6 @@ jobs:
           - x86_64-unknown-linux-gnu
 
     steps:
-      - run: sudo apt-get update
-      - run: sudo apt install -y valgrind
-
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
@@ -57,10 +54,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --package io-uring-bench
-      - uses: actions-rs/cargo@v1
-        with:
-          command: bench
-          args: --package io-uring-bench --bench iai_new_nop
 
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,8 +57,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: bench
-          use-cross: true
-          args: --package io-uring-test --bench iai_new_nop
+          args: --package io-uring-bench --bench iai_new_nop
 
   check:
     runs-on: ubuntu-latest

--- a/io-uring-bench/Cargo.toml
+++ b/io-uring-bench/Cargo.toml
@@ -10,7 +10,10 @@ edition = "2018"
 
 [dependencies]
 io-uring = { path = ".." }
+iou = "0.3"
+uring-sys = "0.7"
 criterion = "0.3"
+iai = "0.1"
 tempfile = "3"
 
 [[bench]]
@@ -21,4 +24,9 @@ harness = false
 [[bench]]
 name = "iovec"
 path = "src/iovec.rs"
+harness = false
+
+[[bench]]
+name = "iai_new_nop"
+path = "src/iai_new_nop.rs"
 harness = false

--- a/io-uring-bench/src/iai_new_nop.rs
+++ b/io-uring-bench/src/iai_new_nop.rs
@@ -1,0 +1,163 @@
+use criterion::black_box;
+
+
+const N: usize = 8;
+
+fn bench_io_uring() {
+    use io_uring::{opcode, IoUring};
+
+    let mut io_uring = IoUring::new(N as _).unwrap();
+
+    for _ in 0..4 {
+        let mut sq = io_uring.submission().available();
+
+        for i in 0..N {
+            let nop_e = opcode::Nop::new()
+                .build()
+                .user_data(black_box(i as _));
+            unsafe {
+                sq.push(nop_e)
+                    .ok()
+                    .unwrap();
+            }
+        }
+
+        drop(sq);
+
+        io_uring.submit_and_wait(N).unwrap();
+
+        io_uring
+            .completion()
+            .available()
+            .map(black_box)
+            .for_each(drop);
+    }
+}
+
+fn bench_iou() {
+    use iou::IoUring;
+
+    let mut io_uring = IoUring::new(N as _).unwrap();
+
+    for _ in 0..4 {
+        let mut sq = io_uring.sq();
+
+        for i in 0..N {
+            unsafe {
+                let mut sqe = sq.prepare_sqe().unwrap();
+                sqe.prep_nop();
+                sqe.set_user_data(black_box(i as _));
+            }
+        }
+
+        sq.submit_and_wait(N as _).unwrap();
+
+        io_uring.cqes()
+            .map(black_box)
+            .for_each(drop);
+    }
+}
+
+fn bench_uring_sys() {
+    use std::{ mem, ptr };
+    use uring_sys::*;
+
+    let mut io_uring = mem::MaybeUninit::<io_uring>::uninit();
+
+    unsafe {
+        if io_uring_queue_init(N as _, io_uring.as_mut_ptr(), 0) != 0 {
+            panic!()
+        }
+    }
+
+    let mut io_uring = unsafe { io_uring.assume_init() };
+
+    for _ in 0..4 {
+        for i in 0..N {
+            unsafe {
+                let sqe = io_uring_get_sqe(&mut io_uring);
+
+                if sqe.is_null() {
+                    panic!()
+                }
+
+                io_uring_prep_nop(sqe);
+                io_uring_sqe_set_data(sqe, i as _);
+            }
+        }
+
+        unsafe {
+            if io_uring_submit_and_wait(&mut io_uring, N as _) < 0 {
+                panic!()
+            }
+        }
+
+        loop {
+            unsafe {
+                let mut cqe = ptr::null_mut();
+                io_uring_peek_cqe(&mut io_uring, &mut cqe);
+
+                if cqe.is_null() {
+                    break
+                }
+
+                black_box(cqe);
+
+                io_uring_cq_advance(&mut io_uring, 1);
+            }
+        }
+    }
+}
+
+fn bench_uring_sys_batch() {
+    use std::{ mem, ptr };
+    use uring_sys::*;
+
+    let mut io_uring = mem::MaybeUninit::<io_uring>::uninit();
+
+    unsafe {
+        if io_uring_queue_init(N as _, io_uring.as_mut_ptr(), 0) != 0 {
+            panic!()
+        }
+    }
+
+    let mut io_uring = unsafe { io_uring.assume_init() };
+
+    for _ in 0..4 {
+        for i in 0..N {
+            unsafe {
+                let sqe = io_uring_get_sqe(&mut io_uring);
+
+                if sqe.is_null() {
+                    panic!()
+                }
+
+                io_uring_prep_nop(sqe);
+                io_uring_sqe_set_data(sqe, i as _);
+            }
+        }
+
+        unsafe {
+            if io_uring_submit_and_wait(&mut io_uring, N as _) < 0 {
+                panic!()
+            }
+        }
+
+        let mut cqes = [ptr::null_mut(); 8];
+
+        unsafe {
+            if io_uring_peek_batch_cqe(&mut io_uring, cqes.as_mut_ptr(), cqes.len() as _) != 8 {
+                panic!()
+            }
+
+            io_uring_cq_advance(&mut io_uring, 8);
+        }
+
+        cqes.iter()
+            .copied()
+            .map(black_box)
+            .for_each(drop);
+    }
+}
+
+iai::main!(bench_io_uring, bench_iou, bench_uring_sys, bench_uring_sys_batch);

--- a/io-uring-bench/src/iai_new_nop.rs
+++ b/io-uring-bench/src/iai_new_nop.rs
@@ -1,6 +1,5 @@
 use criterion::black_box;
 
-
 const N: usize = 8;
 
 fn bench_io_uring() {
@@ -12,13 +11,9 @@ fn bench_io_uring() {
         let mut sq = io_uring.submission().available();
 
         for i in 0..N {
-            let nop_e = opcode::Nop::new()
-                .build()
-                .user_data(black_box(i as _));
+            let nop_e = opcode::Nop::new().build().user_data(black_box(i as _));
             unsafe {
-                sq.push(nop_e)
-                    .ok()
-                    .unwrap();
+                sq.push(nop_e).ok().unwrap();
             }
         }
 
@@ -52,14 +47,12 @@ fn bench_iou() {
 
         sq.submit_and_wait(N as _).unwrap();
 
-        io_uring.cqes()
-            .map(black_box)
-            .for_each(drop);
+        io_uring.cqes().map(black_box).for_each(drop);
     }
 }
 
 fn bench_uring_sys() {
-    use std::{ mem, ptr };
+    use std::{mem, ptr};
     use uring_sys::*;
 
     let mut io_uring = mem::MaybeUninit::<io_uring>::uninit();
@@ -98,7 +91,7 @@ fn bench_uring_sys() {
                 io_uring_peek_cqe(&mut io_uring, &mut cqe);
 
                 if cqe.is_null() {
-                    break
+                    break;
                 }
 
                 black_box(cqe);
@@ -110,7 +103,7 @@ fn bench_uring_sys() {
 }
 
 fn bench_uring_sys_batch() {
-    use std::{ mem, ptr };
+    use std::{mem, ptr};
     use uring_sys::*;
 
     let mut io_uring = mem::MaybeUninit::<io_uring>::uninit();
@@ -153,11 +146,13 @@ fn bench_uring_sys_batch() {
             io_uring_cq_advance(&mut io_uring, 8);
         }
 
-        cqes.iter()
-            .copied()
-            .map(black_box)
-            .for_each(drop);
+        cqes.iter().copied().map(black_box).for_each(drop);
     }
 }
 
-iai::main!(bench_io_uring, bench_iou, bench_uring_sys, bench_uring_sys_batch);
+iai::main!(
+    bench_io_uring,
+    bench_iou,
+    bench_uring_sys,
+    bench_uring_sys_batch
+);


### PR DESCRIPTION
The old bench is easily affected by noise, iai is very helpful.

Result:

```
bench_io_uring
  Instructions:                2421 (No change)
  L1 Accesses:                 3838 (No change)
  L2 Accesses:                   16 (No change)
  RAM Accesses:                  62 (No change)
  Estimated Cycles:            6088 (No change)

bench_iou
  Instructions:                6521 (No change)
  L1 Accesses:                10067 (No change)
  L2 Accesses:                   20 (No change)
  RAM Accesses:                  65 (No change)
  Estimated Cycles:           12442 (No change)

bench_uring_sys
  Instructions:                4788 (No change)
  L1 Accesses:                 7017 (No change)
  L2 Accesses:                   12 (No change)
  RAM Accesses:                  58 (No change)
  Estimated Cycles:            9107 (No change)

bench_uring_sys_batch
  Instructions:                2675 (No change)
  L1 Accesses:                 3843 (No change)
  L2 Accesses:                   10 (No change)
  RAM Accesses:                  53 (No change)
  Estimated Cycles:            5748 (No change)
```