### PR TITLE
Take an &Entry in squeue push

### DIFF
--- a/examples/tcp_echo.rs
+++ b/examples/tcp_echo.rs
@@ -41,7 +41,7 @@ impl AcceptCount {
     pub fn push_to(&mut self, sq: &mut squeue::AvailableQueue) {
         while self.count > 0 {
             unsafe {
-                match sq.push(self.entry.clone()) {
+                match sq.push(&self.entry) {
                     Ok(_) => self.count -= 1,
                     Err(_) => break,
                 }
@@ -90,7 +90,7 @@ fn main() -> anyhow::Result<()> {
 
             match iter.next() {
                 Some(sqe) => unsafe {
-                    let _ = sq.push(sqe);
+                    let _ = sq.push(&sqe);
                 },
                 None => break,
             }
@@ -128,8 +128,8 @@ fn main() -> anyhow::Result<()> {
                         .user_data(poll_token as _);
 
                     unsafe {
-                        if let Err(entry) = sq.push(poll_e) {
-                            backlog.push(entry);
+                        if sq.push(&poll_e).is_err() {
+                            backlog.push(poll_e);
                         }
                     }
                 }
@@ -151,8 +151,8 @@ fn main() -> anyhow::Result<()> {
                         .user_data(token_index as _);
 
                     unsafe {
-                        if let Err(entry) = sq.push(read_e) {
-                            backlog.push(entry);
+                        if sq.push(&read_e).is_err() {
+                            backlog.push(read_e);
                         }
                     }
                 }
@@ -182,8 +182,8 @@ fn main() -> anyhow::Result<()> {
                             .user_data(token_index as _);
 
                         unsafe {
-                            if let Err(entry) = sq.push(write_e) {
-                                backlog.push(entry);
+                            if sq.push(&write_e).is_err() {
+                                backlog.push(write_e);
                             }
                         }
                     }
@@ -223,7 +223,7 @@ fn main() -> anyhow::Result<()> {
                     };
 
                     unsafe {
-                        if let Err(entry) = sq.push(entry) {
+                        if sq.push(&entry).is_err() {
                             backlog.push(entry);
                         }
                     }

--- a/io-uring-bench/src/iai_new_nop.rs
+++ b/io-uring-bench/src/iai_new_nop.rs
@@ -14,7 +14,7 @@ fn bench_io_uring() {
         for i in 0..N {
             let nop_e = opcode::Nop::new().build().user_data(black_box(i as _));
             unsafe {
-                sq.push(nop_e).ok().unwrap();
+                sq.push(&nop_e).ok().unwrap();
             }
         }
 

--- a/io-uring-bench/src/iovec.rs
+++ b/io-uring-bench/src/iovec.rs
@@ -37,8 +37,7 @@ fn bench_iovec(c: &mut Criterion) {
             unsafe {
                 ring.submission()
                     .available()
-                    .push(entry.build())
-                    .ok()
+                    .push(&entry.build())
                     .expect("queue is full");
             }
 
@@ -71,14 +70,12 @@ fn bench_iovec(c: &mut Criterion) {
             unsafe {
                 let mut queue = ring.submission().available();
                 queue
-                    .push(entry.build().flags(squeue::Flags::IO_LINK))
-                    .ok()
+                    .push(&entry.build().flags(squeue::Flags::IO_LINK))
                     .expect("queue is full");
                 for _ in 0..4 {
                     let entry = opcode::Nop::new().build();
                     queue
-                        .push(entry.flags(squeue::Flags::IO_LINK))
-                        .ok()
+                        .push(&entry.flags(squeue::Flags::IO_LINK))
                         .expect("queue is full");
                 }
             }
@@ -101,8 +98,7 @@ fn bench_iovec(c: &mut Criterion) {
 
                 unsafe {
                     queue
-                        .push(entry.build().flags(squeue::Flags::IO_LINK))
-                        .ok()
+                        .push(&entry.build().flags(squeue::Flags::IO_LINK))
                         .expect("queue is full");
                 }
             }
@@ -127,8 +123,7 @@ fn bench_iovec(c: &mut Criterion) {
                 unsafe {
                     ring.submission()
                         .available()
-                        .push(entry.build())
-                        .ok()
+                        .push(&entry.build())
                         .expect("queue is full");
                 }
 

--- a/io-uring-bench/src/nop.rs
+++ b/io-uring-bench/src/nop.rs
@@ -25,7 +25,7 @@ fn bench_normal(c: &mut Criterion) {
                     let mut sq = io_uring.submission().available();
                     while queue.want() {
                         unsafe {
-                            match sq.push(black_box(opcode::Nop::new()).build()) {
+                            match sq.push(&black_box(opcode::Nop::new()).build()) {
                                 Ok(_) => queue.pop(),
                                 Err(_) => break,
                             }

--- a/io-uring-test/src/helper.rs
+++ b/io-uring-test/src/helper.rs
@@ -28,10 +28,9 @@ pub fn write_read(ring: &mut IoUring, fd_in: types::Fd, fd_out: types::Fd) -> an
             .build()
             .user_data(0x01)
             .flags(squeue::Flags::IO_LINK);
-        queue.push(write_e).ok().expect("queue is full");
+        queue.push(&write_e).expect("queue is full");
         queue
-            .push(read_e.build().user_data(0x02))
-            .ok()
+            .push(&read_e.build().user_data(0x02))
             .expect("queue is full");
     }
 
@@ -68,10 +67,9 @@ pub fn writev_readv(ring: &mut IoUring, fd_in: types::Fd, fd_out: types::Fd) -> 
             .build()
             .user_data(0x01)
             .flags(squeue::Flags::IO_LINK);
-        queue.push(write_e).ok().expect("queue is full");
+        queue.push(&write_e).expect("queue is full");
         queue
-            .push(read_e.build().user_data(0x02))
-            .ok()
+            .push(&read_e.build().user_data(0x02))
             .expect("queue is full");
     }
 

--- a/io-uring-test/src/ownedsplit.rs
+++ b/io-uring-test/src/ownedsplit.rs
@@ -19,8 +19,7 @@ fn test_nop(ring: IoUring) -> anyhow::Result<()> {
         unsafe {
             su.submission()
                 .available()
-                .push(nop_e)
-                .ok()
+                .push(&nop_e)
                 .expect("queue is full");
         }
         stu2.submitter().submit()?;

--- a/io-uring-test/src/tests/fs.rs
+++ b/io-uring-test/src/tests/fs.rs
@@ -54,8 +54,7 @@ pub fn test_file_fsync(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()> 
     unsafe {
         let mut queue = ring.submission().available();
         queue
-            .push(fsync_e.build().user_data(0x03))
-            .ok()
+            .push(&fsync_e.build().user_data(0x03))
             .expect("queue is full");
     }
 
@@ -90,8 +89,7 @@ pub fn test_file_fsync_file_range(ring: &mut IoUring, probe: &Probe) -> anyhow::
     unsafe {
         let mut queue = ring.submission().available();
         queue
-            .push(fsync_e.build().user_data(0x04))
-            .ok()
+            .push(&fsync_e.build().user_data(0x04))
             .expect("queue is full");
     }
 
@@ -121,8 +119,7 @@ pub fn test_file_fallocate(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<
     unsafe {
         ring.submission()
             .available()
-            .push(falloc_e.build().user_data(0x10))
-            .ok()
+            .push(&falloc_e.build().user_data(0x10))
             .expect("queue is full");
     }
 
@@ -160,8 +157,7 @@ pub fn test_file_openat2(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()
     unsafe {
         ring.submission()
             .available()
-            .push(open_e.build().user_data(0x11))
-            .ok()
+            .push(&open_e.build().user_data(0x11))
             .expect("queue is full");
     }
 
@@ -195,8 +191,7 @@ pub fn test_file_close(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()> 
     unsafe {
         ring.submission()
             .available()
-            .push(close_e.build().user_data(0x12))
-            .ok()
+            .push(&close_e.build().user_data(0x12))
             .expect("queue is full");
     }
 
@@ -234,8 +229,7 @@ pub fn test_file_cur_pos(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()
     unsafe {
         ring.submission()
             .available()
-            .push(write_e)
-            .ok()
+            .push(&write_e)
             .expect("queue is full");
     }
 
@@ -249,8 +243,7 @@ pub fn test_file_cur_pos(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()
     unsafe {
         ring.submission()
             .available()
-            .push(write_e)
-            .ok()
+            .push(&write_e)
             .expect("queue is full");
     }
 
@@ -261,8 +254,7 @@ pub fn test_file_cur_pos(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()
     unsafe {
         ring.submission()
             .available()
-            .push(read_e.build().user_data(0x03))
-            .ok()
+            .push(&read_e.build().user_data(0x03))
             .expect("queue is full");
     }
 

--- a/io-uring-test/src/tests/net.rs
+++ b/io-uring-test/src/tests/net.rs
@@ -65,10 +65,9 @@ pub fn test_tcp_send_recv(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<(
     unsafe {
         let mut queue = ring.submission().available();
         let send_e = send_e.build().user_data(0x01).flags(squeue::Flags::IO_LINK);
-        queue.push(send_e).ok().expect("queue is full");
+        queue.push(&send_e).expect("queue is full");
         queue
-            .push(recv_e.build().user_data(0x02))
-            .ok()
+            .push(&recv_e.build().user_data(0x02))
             .expect("queue is full");
     }
 
@@ -139,16 +138,14 @@ pub fn test_tcp_sendmsg_recvmsg(ring: &mut IoUring, probe: &Probe) -> anyhow::Re
         let mut queue = ring.submission().available();
         queue
             .push(
-                sendmsg_e
+                &sendmsg_e
                     .build()
                     .user_data(0x01)
                     .flags(squeue::Flags::IO_LINK),
             )
-            .ok()
             .expect("queue is full");
         queue
-            .push(recvmsg_e.build().user_data(0x02))
-            .ok()
+            .push(&recvmsg_e.build().user_data(0x02))
             .expect("queue is full");
     }
 
@@ -198,8 +195,7 @@ pub fn test_tcp_accept(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()> 
     unsafe {
         let mut queue = ring.submission().available();
         queue
-            .push(accept_e.build().user_data(0x0e))
-            .ok()
+            .push(&accept_e.build().user_data(0x0e))
             .expect("queue is full");
     }
 
@@ -249,8 +245,7 @@ pub fn test_tcp_connect(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()>
     unsafe {
         let mut queue = ring.submission().available();
         queue
-            .push(connect_e.build().user_data(0x0f))
-            .ok()
+            .push(&connect_e.build().user_data(0x0f))
             .expect("queue is full");
     }
 

--- a/io-uring-test/src/tests/poll.rs
+++ b/io-uring-test/src/tests/poll.rs
@@ -27,8 +27,7 @@ pub fn test_eventfd_poll(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()
     unsafe {
         let mut queue = ring.submission().available();
         queue
-            .push(poll_e.build().user_data(0x04))
-            .ok()
+            .push(&poll_e.build().user_data(0x04))
             .expect("queue is full");
     }
 
@@ -73,8 +72,7 @@ pub fn test_eventfd_poll_remove(ring: &mut IoUring, probe: &Probe) -> anyhow::Re
     unsafe {
         let mut queue = ring.submission().available();
         queue
-            .push(poll_e.build().user_data(0x05))
-            .ok()
+            .push(&poll_e.build().user_data(0x05))
             .expect("queue is full");
     }
 
@@ -87,8 +85,7 @@ pub fn test_eventfd_poll_remove(ring: &mut IoUring, probe: &Probe) -> anyhow::Re
     unsafe {
         let mut queue = ring.submission().available();
         queue
-            .push(poll_e.build().user_data(0x06))
-            .ok()
+            .push(&poll_e.build().user_data(0x06))
             .expect("queue is full");
     }
 
@@ -136,8 +133,7 @@ pub fn test_eventfd_poll_remove_failed(ring: &mut IoUring, probe: &Probe) -> any
     unsafe {
         let mut queue = ring.submission().available();
         queue
-            .push(poll_e.build().user_data(0x07))
-            .ok()
+            .push(&poll_e.build().user_data(0x07))
             .expect("queue is full");
     }
 
@@ -152,8 +148,7 @@ pub fn test_eventfd_poll_remove_failed(ring: &mut IoUring, probe: &Probe) -> any
     unsafe {
         let mut queue = ring.submission().available();
         queue
-            .push(poll_e.build().user_data(0x08))
-            .ok()
+            .push(&poll_e.build().user_data(0x08))
             .expect("queue is full");
     }
 

--- a/io-uring-test/src/tests/queue.rs
+++ b/io-uring-test/src/tests/queue.rs
@@ -9,7 +9,7 @@ pub fn test_nop(ring: &mut IoUring, _probe: &Probe) -> anyhow::Result<()> {
 
     unsafe {
         let mut queue = ring.submission().available();
-        queue.push(nop_e).ok().expect("queue is full");
+        queue.push(&nop_e).expect("queue is full");
     }
 
     ring.submit_and_wait(1)?;
@@ -39,7 +39,7 @@ pub fn test_batch(ring: &mut IoUring, _probe: &Probe) -> anyhow::Result<()> {
 
         assert_eq!(sq.capacity(), 8);
 
-        sq.push_multiple(&sqes).ok().unwrap();
+        sq.push_multiple(&sqes).unwrap();
 
         assert_eq!(sq.len(), 5);
 
@@ -48,7 +48,7 @@ pub fn test_batch(ring: &mut IoUring, _probe: &Probe) -> anyhow::Result<()> {
 
         assert_eq!(sq.len(), 5);
 
-        sq.push_multiple(&sqes[..3]).ok().unwrap();
+        sq.push_multiple(&sqes[..3]).unwrap();
     }
 
     ring.submit_and_wait(8)?;

--- a/io-uring-test/src/tests/timeout.rs
+++ b/io-uring-test/src/tests/timeout.rs
@@ -16,8 +16,7 @@ pub fn test_timeout(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()> {
     unsafe {
         let mut queue = ring.submission().available();
         queue
-            .push(timeout_e.build().user_data(0x09))
-            .ok()
+            .push(&timeout_e.build().user_data(0x09))
             .expect("queue is full");
     }
 
@@ -41,12 +40,10 @@ pub fn test_timeout(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()> {
     unsafe {
         let mut queue = ring.submission().available();
         queue
-            .push(timeout_e.build().user_data(0x0a))
-            .ok()
+            .push(&timeout_e.build().user_data(0x0a))
             .expect("queue is full");
         queue
-            .push(nop_e.build().user_data(0x0b))
-            .ok()
+            .push(&nop_e.build().user_data(0x0b))
             .expect("queue is full");
     }
 
@@ -92,12 +89,10 @@ pub fn test_timeout_count(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<(
     unsafe {
         let mut queue = ring.submission().available();
         queue
-            .push(timeout_e.build().user_data(0x0c))
-            .ok()
+            .push(&timeout_e.build().user_data(0x0c))
             .expect("queue is full");
         queue
-            .push(nop_e.build().user_data(0x0d))
-            .ok()
+            .push(&nop_e.build().user_data(0x0d))
             .expect("queue is full");
     }
 
@@ -134,8 +129,7 @@ pub fn test_timeout_remove(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<
     unsafe {
         let mut queue = ring.submission().available();
         queue
-            .push(timeout_e.build().user_data(0x10))
-            .ok()
+            .push(&timeout_e.build().user_data(0x10))
             .expect("queue is full");
     }
 
@@ -148,8 +142,7 @@ pub fn test_timeout_remove(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<
     unsafe {
         let mut queue = ring.submission().available();
         queue
-            .push(timeout_e.build().user_data(0x11))
-            .ok()
+            .push(&timeout_e.build().user_data(0x11))
             .expect("queue is full");
     }
 
@@ -186,8 +179,7 @@ pub fn test_timeout_cancel(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<
     unsafe {
         let mut queue = ring.submission().available();
         queue
-            .push(timeout_e.build().user_data(0x10))
-            .ok()
+            .push(&timeout_e.build().user_data(0x10))
             .expect("queue is full");
     }
 
@@ -200,8 +192,7 @@ pub fn test_timeout_cancel(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<
     unsafe {
         let mut queue = ring.submission().available();
         queue
-            .push(timeout_e.build().user_data(0x11))
-            .ok()
+            .push(&timeout_e.build().user_data(0x11))
             .expect("queue is full");
     }
 

--- a/src/squeue.rs
+++ b/src/squeue.rs
@@ -237,13 +237,13 @@ impl AvailableQueue<'_> {
     /// Developers must ensure that parameters of the [`Entry`] (such as buffer) are valid and will
     /// be valid for the entire duration of the operation, otherwise it may cause memory problems.
     #[inline]
-    pub unsafe fn push(&mut self, Entry(entry): Entry) -> Result<(), Entry> {
+    pub unsafe fn push(&mut self, Entry(entry): &Entry) -> Result<(), Insufficient> {
         if !self.is_full() {
-            *self.queue.sqes.add((self.tail & self.ring_mask) as usize) = entry;
+            *self.queue.sqes.add((self.tail & self.ring_mask) as usize) = *entry;
             self.tail = self.tail.wrapping_add(1);
             Ok(())
         } else {
-            Err(Entry(entry))
+            Err(Insufficient(()))
         }
     }
 
@@ -307,4 +307,5 @@ impl Entry {
     }
 }
 
+#[derive(Debug)]
 pub struct Insufficient(());


### PR DESCRIPTION
This provides a more consistent interface between `push` and `push_multiple`. It also removes the need for `.ok()` before `.expect` in many of the tests, as the error type is a printable `Result` already.