### PR TITLE
Resolve &mut unsoundness

### DIFF
--- a/examples/tcp_echo.rs
+++ b/examples/tcp_echo.rs
@@ -2,7 +2,7 @@ use std::net::TcpListener;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::{io, ptr};
 
-use io_uring::{opcode, squeue, types, IoUring};
+use io_uring::{opcode, squeue, types, IoUring, SubmissionQueue};
 use slab::Slab;
 
 #[derive(Clone, Debug)]
@@ -38,7 +38,7 @@ impl AcceptCount {
         }
     }
 
-    pub fn push_to(&mut self, mut sq: squeue::Mut<'_>) {
+    pub fn push_to(&mut self, mut sq: SubmissionQueue<'_>) {
         while self.count > 0 {
             unsafe {
                 match sq.push(&self.entry) {
@@ -85,6 +85,7 @@ fn main() -> anyhow::Result<()> {
                     Err(err) => return Err(err.into()),
                 }
             }
+            sq.sync();
 
             match iter.next() {
                 Some(sqe) => unsafe {

--- a/io-uring-bench/src/iai_new_nop.rs
+++ b/io-uring-bench/src/iai_new_nop.rs
@@ -9,7 +9,7 @@ fn bench_io_uring() {
     let mut io_uring = IoUring::new(N as _).unwrap();
 
     for _ in 0..ITER {
-        let mut sq = io_uring.submission_mut();
+        let mut sq = io_uring.submission();
 
         for i in 0..N {
             let nop_e = opcode::Nop::new().build().user_data(black_box(i as _));
@@ -22,7 +22,7 @@ fn bench_io_uring() {
 
         io_uring.submit_and_wait(N).unwrap();
 
-        io_uring.completion_mut().map(black_box).for_each(drop);
+        io_uring.completion().map(black_box).for_each(drop);
     }
 }
 
@@ -55,12 +55,12 @@ fn bench_io_uring_batch() {
 
     for _ in 0..ITER {
         unsafe {
-            io_uring.submission_mut().push_multiple(&sqes).ok().unwrap();
+            io_uring.submission().push_multiple(&sqes).ok().unwrap();
         }
 
         io_uring.submit_and_wait(N).unwrap();
 
-        let n = io_uring.completion_mut().fill(&mut cqes);
+        let n = io_uring.completion().fill(&mut cqes);
 
         assert_eq!(n, N);
 

--- a/io-uring-bench/src/iai_new_nop.rs
+++ b/io-uring-bench/src/iai_new_nop.rs
@@ -9,7 +9,7 @@ fn bench_io_uring() {
     let mut io_uring = IoUring::new(N as _).unwrap();
 
     for _ in 0..ITER {
-        let mut sq = io_uring.submission().available();
+        let mut sq = io_uring.submission_mut();
 
         for i in 0..N {
             let nop_e = opcode::Nop::new().build().user_data(black_box(i as _));
@@ -22,11 +22,7 @@ fn bench_io_uring() {
 
         io_uring.submit_and_wait(N).unwrap();
 
-        io_uring
-            .completion()
-            .available()
-            .map(black_box)
-            .for_each(drop);
+        io_uring.completion_mut().map(black_box).for_each(drop);
     }
 }
 
@@ -59,17 +55,12 @@ fn bench_io_uring_batch() {
 
     for _ in 0..ITER {
         unsafe {
-            io_uring
-                .submission()
-                .available()
-                .push_multiple(&sqes)
-                .ok()
-                .unwrap();
+            io_uring.submission_mut().push_multiple(&sqes).ok().unwrap();
         }
 
         io_uring.submit_and_wait(N).unwrap();
 
-        let n = io_uring.completion().available().fill(&mut cqes);
+        let n = io_uring.completion_mut().fill(&mut cqes);
 
         assert_eq!(n, N);
 

--- a/io-uring-bench/src/iovec.rs
+++ b/io-uring-bench/src/iovec.rs
@@ -35,14 +35,13 @@ fn bench_iovec(c: &mut Criterion) {
             );
 
             unsafe {
-                ring.submission()
-                    .available()
+                ring.submission_mut()
                     .push(&entry.build())
                     .expect("queue is full");
             }
 
             ring.submit_and_wait(1).unwrap();
-            ring.completion().available().map(black_box).for_each(drop);
+            ring.completion_mut().map(black_box).for_each(drop);
         });
     });
 
@@ -68,7 +67,7 @@ fn bench_iovec(c: &mut Criterion) {
             );
 
             unsafe {
-                let mut queue = ring.submission().available();
+                let mut queue = ring.submission_mut();
                 queue
                     .push(&entry.build().flags(squeue::Flags::IO_LINK))
                     .expect("queue is full");
@@ -81,7 +80,7 @@ fn bench_iovec(c: &mut Criterion) {
             }
 
             ring.submit_and_wait(5).unwrap();
-            ring.completion().available().map(black_box).for_each(drop);
+            ring.completion_mut().map(black_box).for_each(drop);
         });
     });
 
@@ -91,7 +90,7 @@ fn bench_iovec(c: &mut Criterion) {
         let bufs = [&buf[..], &buf2[..], &buf3[..], &buf4[..], &buf5[..]];
 
         b.iter(|| {
-            let mut queue = ring.submission().available();
+            let mut queue = ring.submission_mut();
             for buf in black_box(&bufs) {
                 let entry =
                     opcode::Write::new(types::Fd(fd.as_raw_fd()), buf.as_ptr(), buf.len() as _);
@@ -106,7 +105,7 @@ fn bench_iovec(c: &mut Criterion) {
             drop(queue);
 
             ring.submit_and_wait(bufs.len()).unwrap();
-            ring.completion().available().map(black_box).for_each(drop);
+            ring.completion_mut().map(black_box).for_each(drop);
         });
     });
 
@@ -121,14 +120,13 @@ fn bench_iovec(c: &mut Criterion) {
                     opcode::Write::new(types::Fd(fd.as_raw_fd()), buf.as_ptr(), buf.len() as _);
 
                 unsafe {
-                    ring.submission()
-                        .available()
+                    ring.submission_mut()
                         .push(&entry.build())
                         .expect("queue is full");
                 }
 
                 ring.submit_and_wait(1).unwrap();
-                ring.completion().available().map(black_box).for_each(drop);
+                ring.completion_mut().map(black_box).for_each(drop);
             }
         });
     });

--- a/io-uring-bench/src/iovec.rs
+++ b/io-uring-bench/src/iovec.rs
@@ -35,13 +35,13 @@ fn bench_iovec(c: &mut Criterion) {
             );
 
             unsafe {
-                ring.submission_mut()
+                ring.submission()
                     .push(&entry.build())
                     .expect("queue is full");
             }
 
             ring.submit_and_wait(1).unwrap();
-            ring.completion_mut().map(black_box).for_each(drop);
+            ring.completion().map(black_box).for_each(drop);
         });
     });
 
@@ -67,7 +67,7 @@ fn bench_iovec(c: &mut Criterion) {
             );
 
             unsafe {
-                let mut queue = ring.submission_mut();
+                let mut queue = ring.submission();
                 queue
                     .push(&entry.build().flags(squeue::Flags::IO_LINK))
                     .expect("queue is full");
@@ -80,7 +80,7 @@ fn bench_iovec(c: &mut Criterion) {
             }
 
             ring.submit_and_wait(5).unwrap();
-            ring.completion_mut().map(black_box).for_each(drop);
+            ring.completion().map(black_box).for_each(drop);
         });
     });
 
@@ -90,7 +90,7 @@ fn bench_iovec(c: &mut Criterion) {
         let bufs = [&buf[..], &buf2[..], &buf3[..], &buf4[..], &buf5[..]];
 
         b.iter(|| {
-            let mut queue = ring.submission_mut();
+            let mut queue = ring.submission();
             for buf in black_box(&bufs) {
                 let entry =
                     opcode::Write::new(types::Fd(fd.as_raw_fd()), buf.as_ptr(), buf.len() as _);
@@ -105,7 +105,7 @@ fn bench_iovec(c: &mut Criterion) {
             drop(queue);
 
             ring.submit_and_wait(bufs.len()).unwrap();
-            ring.completion_mut().map(black_box).for_each(drop);
+            ring.completion().map(black_box).for_each(drop);
         });
     });
 
@@ -120,13 +120,13 @@ fn bench_iovec(c: &mut Criterion) {
                     opcode::Write::new(types::Fd(fd.as_raw_fd()), buf.as_ptr(), buf.len() as _);
 
                 unsafe {
-                    ring.submission_mut()
+                    ring.submission()
                         .push(&entry.build())
                         .expect("queue is full");
                 }
 
                 ring.submit_and_wait(1).unwrap();
-                ring.completion_mut().map(black_box).for_each(drop);
+                ring.completion().map(black_box).for_each(drop);
             }
         });
     });

--- a/io-uring-bench/src/nop.rs
+++ b/io-uring-bench/src/nop.rs
@@ -22,7 +22,7 @@ fn bench_normal(c: &mut Criterion) {
 
             while queue.want() {
                 {
-                    let mut sq = io_uring.submission().available();
+                    let mut sq = io_uring.submission_mut();
                     while queue.want() {
                         unsafe {
                             match sq.push(&black_box(opcode::Nop::new()).build()) {
@@ -35,11 +35,7 @@ fn bench_normal(c: &mut Criterion) {
 
                 io_uring.submit_and_wait(16).unwrap();
 
-                io_uring
-                    .completion()
-                    .available()
-                    .map(black_box)
-                    .for_each(drop);
+                io_uring.completion_mut().map(black_box).for_each(drop);
             }
         });
     });

--- a/io-uring-bench/src/nop.rs
+++ b/io-uring-bench/src/nop.rs
@@ -22,7 +22,7 @@ fn bench_normal(c: &mut Criterion) {
 
             while queue.want() {
                 {
-                    let mut sq = io_uring.submission_mut();
+                    let mut sq = io_uring.submission();
                     while queue.want() {
                         unsafe {
                             match sq.push(&black_box(opcode::Nop::new()).build()) {
@@ -35,7 +35,7 @@ fn bench_normal(c: &mut Criterion) {
 
                 io_uring.submit_and_wait(16).unwrap();
 
-                io_uring.completion_mut().map(black_box).for_each(drop);
+                io_uring.completion().map(black_box).for_each(drop);
             }
         });
     });

--- a/io-uring-test/src/helper.rs
+++ b/io-uring-test/src/helper.rs
@@ -23,7 +23,7 @@ pub fn write_read(ring: &mut IoUring, fd_in: types::Fd, fd_out: types::Fd) -> an
     let read_e = opcode::Read::new(fd_out, output.as_mut_ptr(), output.len() as _);
 
     unsafe {
-        let mut queue = ring.submission().available();
+        let mut queue = ring.submission_mut();
         let write_e = write_e
             .build()
             .user_data(0x01)
@@ -36,7 +36,7 @@ pub fn write_read(ring: &mut IoUring, fd_in: types::Fd, fd_out: types::Fd) -> an
 
     assert_eq!(ring.submit_and_wait(2)?, 2);
 
-    let cqes = ring.completion().available().collect::<Vec<_>>();
+    let cqes = ring.completion_mut().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 2);
     assert_eq!(cqes[0].user_data(), 0x01);
@@ -62,7 +62,7 @@ pub fn writev_readv(ring: &mut IoUring, fd_in: types::Fd, fd_out: types::Fd) -> 
     let read_e = opcode::Readv::new(fd_out, output3.as_mut_ptr().cast(), output3.len() as _);
 
     unsafe {
-        let mut queue = ring.submission().available();
+        let mut queue = ring.submission_mut();
         let write_e = write_e
             .build()
             .user_data(0x01)
@@ -75,7 +75,7 @@ pub fn writev_readv(ring: &mut IoUring, fd_in: types::Fd, fd_out: types::Fd) -> 
 
     ring.submit_and_wait(2)?;
 
-    let cqes = ring.completion().available().collect::<Vec<_>>();
+    let cqes = ring.completion_mut().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 2);
     assert_eq!(cqes[0].user_data(), 0x01);

--- a/io-uring-test/src/helper.rs
+++ b/io-uring-test/src/helper.rs
@@ -23,7 +23,7 @@ pub fn write_read(ring: &mut IoUring, fd_in: types::Fd, fd_out: types::Fd) -> an
     let read_e = opcode::Read::new(fd_out, output.as_mut_ptr(), output.len() as _);
 
     unsafe {
-        let mut queue = ring.submission_mut();
+        let mut queue = ring.submission();
         let write_e = write_e
             .build()
             .user_data(0x01)
@@ -36,7 +36,7 @@ pub fn write_read(ring: &mut IoUring, fd_in: types::Fd, fd_out: types::Fd) -> an
 
     assert_eq!(ring.submit_and_wait(2)?, 2);
 
-    let cqes = ring.completion_mut().collect::<Vec<_>>();
+    let cqes = ring.completion().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 2);
     assert_eq!(cqes[0].user_data(), 0x01);
@@ -62,7 +62,7 @@ pub fn writev_readv(ring: &mut IoUring, fd_in: types::Fd, fd_out: types::Fd) -> 
     let read_e = opcode::Readv::new(fd_out, output3.as_mut_ptr().cast(), output3.len() as _);
 
     unsafe {
-        let mut queue = ring.submission_mut();
+        let mut queue = ring.submission();
         let write_e = write_e
             .build()
             .user_data(0x01)
@@ -75,7 +75,7 @@ pub fn writev_readv(ring: &mut IoUring, fd_in: types::Fd, fd_out: types::Fd) -> 
 
     ring.submit_and_wait(2)?;
 
-    let cqes = ring.completion_mut().collect::<Vec<_>>();
+    let cqes = ring.completion().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 2);
     assert_eq!(cqes[0].user_data(), 0x01);

--- a/io-uring-test/src/ownedsplit.rs
+++ b/io-uring-test/src/ownedsplit.rs
@@ -17,7 +17,7 @@ fn test_nop(ring: IoUring) -> anyhow::Result<()> {
 
     let sj = thread::spawn(move || {
         unsafe {
-            su.submission_mut().push(&nop_e).expect("queue is full");
+            su.submission().push(&nop_e).expect("queue is full");
         }
         stu2.submitter().submit()?;
         Ok(()) as std::io::Result<()>
@@ -25,7 +25,7 @@ fn test_nop(ring: IoUring) -> anyhow::Result<()> {
 
     stu.submitter().submit_and_wait(1)?;
 
-    let cqes = cu.completion_mut().collect::<Vec<_>>();
+    let cqes = cu.completion().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x42);

--- a/io-uring-test/src/ownedsplit.rs
+++ b/io-uring-test/src/ownedsplit.rs
@@ -17,10 +17,7 @@ fn test_nop(ring: IoUring) -> anyhow::Result<()> {
 
     let sj = thread::spawn(move || {
         unsafe {
-            su.submission()
-                .available()
-                .push(&nop_e)
-                .expect("queue is full");
+            su.submission_mut().push(&nop_e).expect("queue is full");
         }
         stu2.submitter().submit()?;
         Ok(()) as std::io::Result<()>
@@ -28,7 +25,7 @@ fn test_nop(ring: IoUring) -> anyhow::Result<()> {
 
     stu.submitter().submit_and_wait(1)?;
 
-    let cqes = cu.completion().available().collect::<Vec<_>>();
+    let cqes = cu.completion_mut().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x42);

--- a/io-uring-test/src/tests/fs.rs
+++ b/io-uring-test/src/tests/fs.rs
@@ -52,15 +52,14 @@ pub fn test_file_fsync(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()> 
     let fsync_e = opcode::Fsync::new(fd);
 
     unsafe {
-        let mut queue = ring.submission().available();
-        queue
+        ring.submission_mut()
             .push(&fsync_e.build().user_data(0x03))
             .expect("queue is full");
     }
 
     ring.submit_and_wait(1)?;
 
-    let cqes = ring.completion().available().collect::<Vec<_>>();
+    let cqes = ring.completion_mut().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x03);
@@ -87,15 +86,14 @@ pub fn test_file_fsync_file_range(ring: &mut IoUring, probe: &Probe) -> anyhow::
     let fsync_e = opcode::SyncFileRange::new(fd, 1024).offset(3 * 1024);
 
     unsafe {
-        let mut queue = ring.submission().available();
-        queue
+        ring.submission_mut()
             .push(&fsync_e.build().user_data(0x04))
             .expect("queue is full");
     }
 
     ring.submit_and_wait(1)?;
 
-    let cqes = ring.completion().available().collect::<Vec<_>>();
+    let cqes = ring.completion_mut().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x04);
@@ -117,15 +115,14 @@ pub fn test_file_fallocate(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<
     let falloc_e = opcode::Fallocate::new(fd, 1024);
 
     unsafe {
-        ring.submission()
-            .available()
+        ring.submission_mut()
             .push(&falloc_e.build().user_data(0x10))
             .expect("queue is full");
     }
 
     ring.submit_and_wait(1)?;
 
-    let cqes = ring.completion().available().collect::<Vec<_>>();
+    let cqes = ring.completion_mut().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x10);
@@ -155,15 +152,14 @@ pub fn test_file_openat2(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()
     let open_e = opcode::OpenAt2::new(dirfd, path.as_ptr(), &openhow);
 
     unsafe {
-        ring.submission()
-            .available()
+        ring.submission_mut()
             .push(&open_e.build().user_data(0x11))
             .expect("queue is full");
     }
 
     ring.submit_and_wait(1)?;
 
-    let cqes = ring.completion().available().collect::<Vec<_>>();
+    let cqes = ring.completion_mut().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x11);
@@ -189,15 +185,14 @@ pub fn test_file_close(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()> 
     let close_e = opcode::Close::new(fd);
 
     unsafe {
-        ring.submission()
-            .available()
+        ring.submission_mut()
             .push(&close_e.build().user_data(0x12))
             .expect("queue is full");
     }
 
     ring.submit_and_wait(1)?;
 
-    let cqes = ring.completion().available().collect::<Vec<_>>();
+    let cqes = ring.completion_mut().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x12);
@@ -227,10 +222,7 @@ pub fn test_file_cur_pos(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()
         .user_data(0x01);
 
     unsafe {
-        ring.submission()
-            .available()
-            .push(&write_e)
-            .expect("queue is full");
+        ring.submission_mut().push(&write_e).expect("queue is full");
     }
 
     ring.submit_and_wait(1)?;
@@ -241,10 +233,7 @@ pub fn test_file_cur_pos(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()
         .user_data(0x02);
 
     unsafe {
-        ring.submission()
-            .available()
-            .push(&write_e)
-            .expect("queue is full");
+        ring.submission_mut().push(&write_e).expect("queue is full");
     }
 
     ring.submit_and_wait(2)?;
@@ -252,15 +241,14 @@ pub fn test_file_cur_pos(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()
     let read_e = opcode::Read::new(fd, output.as_mut_ptr(), output.len() as _);
 
     unsafe {
-        ring.submission()
-            .available()
+        ring.submission_mut()
             .push(&read_e.build().user_data(0x03))
             .expect("queue is full");
     }
 
     ring.submit_and_wait(3)?;
 
-    let cqes = ring.completion().available().collect::<Vec<_>>();
+    let cqes = ring.completion_mut().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 3);
     assert_eq!(cqes[0].user_data(), 0x01);

--- a/io-uring-test/src/tests/fs.rs
+++ b/io-uring-test/src/tests/fs.rs
@@ -52,14 +52,14 @@ pub fn test_file_fsync(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()> 
     let fsync_e = opcode::Fsync::new(fd);
 
     unsafe {
-        ring.submission_mut()
+        ring.submission()
             .push(&fsync_e.build().user_data(0x03))
             .expect("queue is full");
     }
 
     ring.submit_and_wait(1)?;
 
-    let cqes = ring.completion_mut().collect::<Vec<_>>();
+    let cqes = ring.completion().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x03);
@@ -86,14 +86,14 @@ pub fn test_file_fsync_file_range(ring: &mut IoUring, probe: &Probe) -> anyhow::
     let fsync_e = opcode::SyncFileRange::new(fd, 1024).offset(3 * 1024);
 
     unsafe {
-        ring.submission_mut()
+        ring.submission()
             .push(&fsync_e.build().user_data(0x04))
             .expect("queue is full");
     }
 
     ring.submit_and_wait(1)?;
 
-    let cqes = ring.completion_mut().collect::<Vec<_>>();
+    let cqes = ring.completion().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x04);
@@ -115,14 +115,14 @@ pub fn test_file_fallocate(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<
     let falloc_e = opcode::Fallocate::new(fd, 1024);
 
     unsafe {
-        ring.submission_mut()
+        ring.submission()
             .push(&falloc_e.build().user_data(0x10))
             .expect("queue is full");
     }
 
     ring.submit_and_wait(1)?;
 
-    let cqes = ring.completion_mut().collect::<Vec<_>>();
+    let cqes = ring.completion().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x10);
@@ -152,14 +152,14 @@ pub fn test_file_openat2(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()
     let open_e = opcode::OpenAt2::new(dirfd, path.as_ptr(), &openhow);
 
     unsafe {
-        ring.submission_mut()
+        ring.submission()
             .push(&open_e.build().user_data(0x11))
             .expect("queue is full");
     }
 
     ring.submit_and_wait(1)?;
 
-    let cqes = ring.completion_mut().collect::<Vec<_>>();
+    let cqes = ring.completion().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x11);
@@ -185,14 +185,14 @@ pub fn test_file_close(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()> 
     let close_e = opcode::Close::new(fd);
 
     unsafe {
-        ring.submission_mut()
+        ring.submission()
             .push(&close_e.build().user_data(0x12))
             .expect("queue is full");
     }
 
     ring.submit_and_wait(1)?;
 
-    let cqes = ring.completion_mut().collect::<Vec<_>>();
+    let cqes = ring.completion().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x12);
@@ -222,7 +222,7 @@ pub fn test_file_cur_pos(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()
         .user_data(0x01);
 
     unsafe {
-        ring.submission_mut().push(&write_e).expect("queue is full");
+        ring.submission().push(&write_e).expect("queue is full");
     }
 
     ring.submit_and_wait(1)?;
@@ -233,7 +233,7 @@ pub fn test_file_cur_pos(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()
         .user_data(0x02);
 
     unsafe {
-        ring.submission_mut().push(&write_e).expect("queue is full");
+        ring.submission().push(&write_e).expect("queue is full");
     }
 
     ring.submit_and_wait(2)?;
@@ -241,14 +241,14 @@ pub fn test_file_cur_pos(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()
     let read_e = opcode::Read::new(fd, output.as_mut_ptr(), output.len() as _);
 
     unsafe {
-        ring.submission_mut()
+        ring.submission()
             .push(&read_e.build().user_data(0x03))
             .expect("queue is full");
     }
 
     ring.submit_and_wait(3)?;
 
-    let cqes = ring.completion_mut().collect::<Vec<_>>();
+    let cqes = ring.completion().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 3);
     assert_eq!(cqes[0].user_data(), 0x01);

--- a/io-uring-test/src/tests/net.rs
+++ b/io-uring-test/src/tests/net.rs
@@ -63,7 +63,7 @@ pub fn test_tcp_send_recv(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<(
     let recv_e = opcode::Recv::new(fd, output.as_mut_ptr(), output.len() as _);
 
     unsafe {
-        let mut queue = ring.submission_mut();
+        let mut queue = ring.submission();
         let send_e = send_e.build().user_data(0x01).flags(squeue::Flags::IO_LINK);
         queue.push(&send_e).expect("queue is full");
         queue
@@ -73,7 +73,7 @@ pub fn test_tcp_send_recv(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<(
 
     ring.submit_and_wait(2)?;
 
-    let cqes = ring.completion_mut().collect::<Vec<_>>();
+    let cqes = ring.completion().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 2);
     assert_eq!(cqes[0].user_data(), 0x01);
@@ -135,7 +135,7 @@ pub fn test_tcp_sendmsg_recvmsg(ring: &mut IoUring, probe: &Probe) -> anyhow::Re
 
     // submit
     unsafe {
-        let mut queue = ring.submission_mut();
+        let mut queue = ring.submission();
         queue
             .push(
                 &sendmsg_e
@@ -152,7 +152,7 @@ pub fn test_tcp_sendmsg_recvmsg(ring: &mut IoUring, probe: &Probe) -> anyhow::Re
     ring.submit_and_wait(2)?;
 
     // complete
-    let cqes = ring.completion_mut().collect::<Vec<_>>();
+    let cqes = ring.completion().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 2);
     assert_eq!(cqes[0].user_data(), 0x01);
@@ -193,14 +193,14 @@ pub fn test_tcp_accept(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()> 
     let accept_e = opcode::Accept::new(fd, &mut sockaddr, &mut addrlen);
 
     unsafe {
-        ring.submission_mut()
+        ring.submission()
             .push(&accept_e.build().user_data(0x0e))
             .expect("queue is full");
     }
 
     ring.submit_and_wait(1)?;
 
-    let cqes = ring.completion_mut().collect::<Vec<_>>();
+    let cqes = ring.completion().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x0e);
@@ -242,14 +242,14 @@ pub fn test_tcp_connect(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()>
     );
 
     unsafe {
-        ring.submission_mut()
+        ring.submission()
             .push(&connect_e.build().user_data(0x0f))
             .expect("queue is full");
     }
 
     ring.submit_and_wait(1)?;
 
-    let cqes = ring.completion_mut().collect::<Vec<_>>();
+    let cqes = ring.completion().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x0f);

--- a/io-uring-test/src/tests/net.rs
+++ b/io-uring-test/src/tests/net.rs
@@ -63,7 +63,7 @@ pub fn test_tcp_send_recv(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<(
     let recv_e = opcode::Recv::new(fd, output.as_mut_ptr(), output.len() as _);
 
     unsafe {
-        let mut queue = ring.submission().available();
+        let mut queue = ring.submission_mut();
         let send_e = send_e.build().user_data(0x01).flags(squeue::Flags::IO_LINK);
         queue.push(&send_e).expect("queue is full");
         queue
@@ -73,7 +73,7 @@ pub fn test_tcp_send_recv(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<(
 
     ring.submit_and_wait(2)?;
 
-    let cqes = ring.completion().available().collect::<Vec<_>>();
+    let cqes = ring.completion_mut().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 2);
     assert_eq!(cqes[0].user_data(), 0x01);
@@ -135,7 +135,7 @@ pub fn test_tcp_sendmsg_recvmsg(ring: &mut IoUring, probe: &Probe) -> anyhow::Re
 
     // submit
     unsafe {
-        let mut queue = ring.submission().available();
+        let mut queue = ring.submission_mut();
         queue
             .push(
                 &sendmsg_e
@@ -152,7 +152,7 @@ pub fn test_tcp_sendmsg_recvmsg(ring: &mut IoUring, probe: &Probe) -> anyhow::Re
     ring.submit_and_wait(2)?;
 
     // complete
-    let cqes = ring.completion().available().collect::<Vec<_>>();
+    let cqes = ring.completion_mut().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 2);
     assert_eq!(cqes[0].user_data(), 0x01);
@@ -193,15 +193,14 @@ pub fn test_tcp_accept(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()> 
     let accept_e = opcode::Accept::new(fd, &mut sockaddr, &mut addrlen);
 
     unsafe {
-        let mut queue = ring.submission().available();
-        queue
+        ring.submission_mut()
             .push(&accept_e.build().user_data(0x0e))
             .expect("queue is full");
     }
 
     ring.submit_and_wait(1)?;
 
-    let cqes = ring.completion().available().collect::<Vec<_>>();
+    let cqes = ring.completion_mut().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x0e);
@@ -243,15 +242,14 @@ pub fn test_tcp_connect(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()>
     );
 
     unsafe {
-        let mut queue = ring.submission().available();
-        queue
+        ring.submission_mut()
             .push(&connect_e.build().user_data(0x0f))
             .expect("queue is full");
     }
 
     ring.submit_and_wait(1)?;
 
-    let cqes = ring.completion().available().collect::<Vec<_>>();
+    let cqes = ring.completion_mut().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x0f);

--- a/io-uring-test/src/tests/poll.rs
+++ b/io-uring-test/src/tests/poll.rs
@@ -25,7 +25,7 @@ pub fn test_eventfd_poll(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()
     let poll_e = opcode::PollAdd::new(types::Fd(fd.as_raw_fd()), libc::POLLIN as _);
 
     unsafe {
-        let mut queue = ring.submission().available();
+        let mut queue = ring.submission_mut();
         queue
             .push(&poll_e.build().user_data(0x04))
             .expect("queue is full");
@@ -33,12 +33,12 @@ pub fn test_eventfd_poll(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()
 
     ring.submit()?;
     thread::sleep(Duration::from_millis(200));
-    assert_eq!(ring.completion().len(), 0);
+    assert_eq!(ring.completion_mut().len(), 0);
 
     fd.write(&0x1u64.to_ne_bytes())?;
     ring.submit_and_wait(1)?;
 
-    let cqes = ring.completion().available().collect::<Vec<_>>();
+    let cqes = ring.completion_mut().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x04);
@@ -70,7 +70,7 @@ pub fn test_eventfd_poll_remove(ring: &mut IoUring, probe: &Probe) -> anyhow::Re
     let poll_e = opcode::PollAdd::new(types::Fd(fd.as_raw_fd()), libc::POLLIN as _);
 
     unsafe {
-        let mut queue = ring.submission().available();
+        let mut queue = ring.submission_mut();
         queue
             .push(&poll_e.build().user_data(0x05))
             .expect("queue is full");
@@ -83,7 +83,7 @@ pub fn test_eventfd_poll_remove(ring: &mut IoUring, probe: &Probe) -> anyhow::Re
     let poll_e = opcode::PollRemove::new(0x05);
 
     unsafe {
-        let mut queue = ring.submission().available();
+        let mut queue = ring.submission_mut();
         queue
             .push(&poll_e.build().user_data(0x06))
             .expect("queue is full");
@@ -96,7 +96,7 @@ pub fn test_eventfd_poll_remove(ring: &mut IoUring, probe: &Probe) -> anyhow::Re
     fd.write(&0x1u64.to_ne_bytes())?;
     ring.submit_and_wait(2)?;
 
-    let mut cqes = ring.completion().available().collect::<Vec<_>>();
+    let mut cqes = ring.completion_mut().collect::<Vec<_>>();
     cqes.sort_by_key(|cqe| cqe.user_data());
 
     assert_eq!(cqes.len(), 2);
@@ -131,7 +131,7 @@ pub fn test_eventfd_poll_remove_failed(ring: &mut IoUring, probe: &Probe) -> any
     let poll_e = opcode::PollAdd::new(types::Fd(fd.as_raw_fd()), libc::POLLIN as _);
 
     unsafe {
-        let mut queue = ring.submission().available();
+        let mut queue = ring.submission_mut();
         queue
             .push(&poll_e.build().user_data(0x07))
             .expect("queue is full");
@@ -139,14 +139,14 @@ pub fn test_eventfd_poll_remove_failed(ring: &mut IoUring, probe: &Probe) -> any
 
     fd.write(&0x1u64.to_ne_bytes())?;
     ring.submit_and_wait(1)?;
-    assert_eq!(ring.completion().len(), 1);
+    assert_eq!(ring.completion_mut().len(), 1);
 
     // remove poll
 
     let poll_e = opcode::PollRemove::new(0x08);
 
     unsafe {
-        let mut queue = ring.submission().available();
+        let mut queue = ring.submission_mut();
         queue
             .push(&poll_e.build().user_data(0x08))
             .expect("queue is full");
@@ -154,7 +154,7 @@ pub fn test_eventfd_poll_remove_failed(ring: &mut IoUring, probe: &Probe) -> any
 
     ring.submit_and_wait(2)?;
 
-    let mut cqes = ring.completion().available().collect::<Vec<_>>();
+    let mut cqes = ring.completion_mut().collect::<Vec<_>>();
     cqes.sort_by_key(|cqe| cqe.user_data());
 
     assert_eq!(cqes.len(), 2);

--- a/io-uring-test/src/tests/poll.rs
+++ b/io-uring-test/src/tests/poll.rs
@@ -25,7 +25,7 @@ pub fn test_eventfd_poll(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()
     let poll_e = opcode::PollAdd::new(types::Fd(fd.as_raw_fd()), libc::POLLIN as _);
 
     unsafe {
-        let mut queue = ring.submission_mut();
+        let mut queue = ring.submission();
         queue
             .push(&poll_e.build().user_data(0x04))
             .expect("queue is full");
@@ -33,12 +33,12 @@ pub fn test_eventfd_poll(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()
 
     ring.submit()?;
     thread::sleep(Duration::from_millis(200));
-    assert_eq!(ring.completion_mut().len(), 0);
+    assert_eq!(ring.completion().len(), 0);
 
     fd.write(&0x1u64.to_ne_bytes())?;
     ring.submit_and_wait(1)?;
 
-    let cqes = ring.completion_mut().collect::<Vec<_>>();
+    let cqes = ring.completion().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x04);
@@ -70,7 +70,7 @@ pub fn test_eventfd_poll_remove(ring: &mut IoUring, probe: &Probe) -> anyhow::Re
     let poll_e = opcode::PollAdd::new(types::Fd(fd.as_raw_fd()), libc::POLLIN as _);
 
     unsafe {
-        let mut queue = ring.submission_mut();
+        let mut queue = ring.submission();
         queue
             .push(&poll_e.build().user_data(0x05))
             .expect("queue is full");
@@ -83,7 +83,7 @@ pub fn test_eventfd_poll_remove(ring: &mut IoUring, probe: &Probe) -> anyhow::Re
     let poll_e = opcode::PollRemove::new(0x05);
 
     unsafe {
-        let mut queue = ring.submission_mut();
+        let mut queue = ring.submission();
         queue
             .push(&poll_e.build().user_data(0x06))
             .expect("queue is full");
@@ -96,7 +96,7 @@ pub fn test_eventfd_poll_remove(ring: &mut IoUring, probe: &Probe) -> anyhow::Re
     fd.write(&0x1u64.to_ne_bytes())?;
     ring.submit_and_wait(2)?;
 
-    let mut cqes = ring.completion_mut().collect::<Vec<_>>();
+    let mut cqes = ring.completion().collect::<Vec<_>>();
     cqes.sort_by_key(|cqe| cqe.user_data());
 
     assert_eq!(cqes.len(), 2);
@@ -131,7 +131,7 @@ pub fn test_eventfd_poll_remove_failed(ring: &mut IoUring, probe: &Probe) -> any
     let poll_e = opcode::PollAdd::new(types::Fd(fd.as_raw_fd()), libc::POLLIN as _);
 
     unsafe {
-        let mut queue = ring.submission_mut();
+        let mut queue = ring.submission();
         queue
             .push(&poll_e.build().user_data(0x07))
             .expect("queue is full");
@@ -139,14 +139,14 @@ pub fn test_eventfd_poll_remove_failed(ring: &mut IoUring, probe: &Probe) -> any
 
     fd.write(&0x1u64.to_ne_bytes())?;
     ring.submit_and_wait(1)?;
-    assert_eq!(ring.completion_mut().len(), 1);
+    assert_eq!(ring.completion().len(), 1);
 
     // remove poll
 
     let poll_e = opcode::PollRemove::new(0x08);
 
     unsafe {
-        let mut queue = ring.submission_mut();
+        let mut queue = ring.submission();
         queue
             .push(&poll_e.build().user_data(0x08))
             .expect("queue is full");
@@ -154,7 +154,7 @@ pub fn test_eventfd_poll_remove_failed(ring: &mut IoUring, probe: &Probe) -> any
 
     ring.submit_and_wait(2)?;
 
-    let mut cqes = ring.completion_mut().collect::<Vec<_>>();
+    let mut cqes = ring.completion().collect::<Vec<_>>();
     cqes.sort_by_key(|cqe| cqe.user_data());
 
     assert_eq!(cqes.len(), 2);

--- a/io-uring-test/src/tests/queue.rs
+++ b/io-uring-test/src/tests/queue.rs
@@ -8,13 +8,13 @@ pub fn test_nop(ring: &mut IoUring, _probe: &Probe) -> anyhow::Result<()> {
     let nop_e = opcode::Nop::new().build().user_data(0x42);
 
     unsafe {
-        let mut queue = ring.submission().available();
+        let mut queue = ring.submission_mut();
         queue.push(&nop_e).expect("queue is full");
     }
 
     ring.submit_and_wait(1)?;
 
-    let cqes = ring.completion().available().collect::<Vec<_>>();
+    let cqes = ring.completion_mut().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x42);
@@ -31,11 +31,11 @@ pub fn test_batch(ring: &mut IoUring, _probe: &Probe) -> anyhow::Result<()> {
 
     println!("test batch");
 
-    assert!(ring.completion().is_empty());
+    assert!(ring.completion_mut().is_empty());
 
     unsafe {
         let sqes = vec![opcode::Nop::new().build().user_data(0x09); 5];
-        let mut sq = ring.submission().available();
+        let mut sq = ring.submission_mut();
 
         assert_eq!(sq.capacity(), 8);
 
@@ -55,7 +55,7 @@ pub fn test_batch(ring: &mut IoUring, _probe: &Probe) -> anyhow::Result<()> {
 
     let mut cqes = (0..10).map(|_| MaybeUninit::uninit()).collect::<Vec<_>>();
 
-    let n = ring.completion().available().fill(&mut cqes);
+    let n = ring.completion_mut().fill(&mut cqes);
 
     assert_eq!(n, 8);
 

--- a/io-uring-test/src/tests/queue.rs
+++ b/io-uring-test/src/tests/queue.rs
@@ -8,13 +8,13 @@ pub fn test_nop(ring: &mut IoUring, _probe: &Probe) -> anyhow::Result<()> {
     let nop_e = opcode::Nop::new().build().user_data(0x42);
 
     unsafe {
-        let mut queue = ring.submission_mut();
+        let mut queue = ring.submission();
         queue.push(&nop_e).expect("queue is full");
     }
 
     ring.submit_and_wait(1)?;
 
-    let cqes = ring.completion_mut().collect::<Vec<_>>();
+    let cqes = ring.completion().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x42);
@@ -31,11 +31,11 @@ pub fn test_batch(ring: &mut IoUring, _probe: &Probe) -> anyhow::Result<()> {
 
     println!("test batch");
 
-    assert!(ring.completion_mut().is_empty());
+    assert!(ring.completion().is_empty());
 
     unsafe {
         let sqes = vec![opcode::Nop::new().build().user_data(0x09); 5];
-        let mut sq = ring.submission_mut();
+        let mut sq = ring.submission();
 
         assert_eq!(sq.capacity(), 8);
 
@@ -55,7 +55,7 @@ pub fn test_batch(ring: &mut IoUring, _probe: &Probe) -> anyhow::Result<()> {
 
     let mut cqes = (0..10).map(|_| MaybeUninit::uninit()).collect::<Vec<_>>();
 
-    let n = ring.completion_mut().fill(&mut cqes);
+    let n = ring.completion().fill(&mut cqes);
 
     assert_eq!(n, 8);
 

--- a/io-uring-test/src/tests/timeout.rs
+++ b/io-uring-test/src/tests/timeout.rs
@@ -14,7 +14,7 @@ pub fn test_timeout(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()> {
     let timeout_e = opcode::Timeout::new(&ts);
 
     unsafe {
-        let mut queue = ring.submission().available();
+        let mut queue = ring.submission_mut();
         queue
             .push(&timeout_e.build().user_data(0x09))
             .expect("queue is full");
@@ -25,7 +25,7 @@ pub fn test_timeout(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()> {
 
     assert_eq!(start.elapsed().as_secs(), 1);
 
-    let cqes = ring.completion().available().collect::<Vec<_>>();
+    let cqes = ring.completion_mut().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x09);
@@ -38,7 +38,7 @@ pub fn test_timeout(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()> {
     let nop_e = opcode::Nop::new();
 
     unsafe {
-        let mut queue = ring.submission().available();
+        let mut queue = ring.submission_mut();
         queue
             .push(&timeout_e.build().user_data(0x0a))
             .expect("queue is full");
@@ -54,7 +54,7 @@ pub fn test_timeout(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()> {
 
     assert_eq!(start.elapsed().as_secs(), 0);
 
-    let cqes = ring.completion().available().collect::<Vec<_>>();
+    let cqes = ring.completion_mut().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x0b);
@@ -66,7 +66,7 @@ pub fn test_timeout(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()> {
 
     assert_eq!(start.elapsed().as_secs(), 1);
 
-    let cqes = ring.completion().available().collect::<Vec<_>>();
+    let cqes = ring.completion_mut().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x0a);
@@ -87,7 +87,7 @@ pub fn test_timeout_count(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<(
     let nop_e = opcode::Nop::new();
 
     unsafe {
-        let mut queue = ring.submission().available();
+        let mut queue = ring.submission_mut();
         queue
             .push(&timeout_e.build().user_data(0x0c))
             .expect("queue is full");
@@ -101,7 +101,7 @@ pub fn test_timeout_count(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<(
 
     assert_eq!(start.elapsed().as_secs(), 0);
 
-    let mut cqes = ring.completion().available().collect::<Vec<_>>();
+    let mut cqes = ring.completion_mut().collect::<Vec<_>>();
     cqes.sort_by_key(|cqe| cqe.user_data());
 
     assert_eq!(cqes.len(), 2);
@@ -127,7 +127,7 @@ pub fn test_timeout_remove(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<
     let timeout_e = opcode::Timeout::new(&ts);
 
     unsafe {
-        let mut queue = ring.submission().available();
+        let mut queue = ring.submission_mut();
         queue
             .push(&timeout_e.build().user_data(0x10))
             .expect("queue is full");
@@ -140,7 +140,7 @@ pub fn test_timeout_remove(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<
     let timeout_e = opcode::TimeoutRemove::new(0x10);
 
     unsafe {
-        let mut queue = ring.submission().available();
+        let mut queue = ring.submission_mut();
         queue
             .push(&timeout_e.build().user_data(0x11))
             .expect("queue is full");
@@ -151,7 +151,7 @@ pub fn test_timeout_remove(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<
 
     assert_eq!(start.elapsed().as_secs(), 0);
 
-    let mut cqes = ring.completion().available().collect::<Vec<_>>();
+    let mut cqes = ring.completion_mut().collect::<Vec<_>>();
     cqes.sort_by_key(|cqe| cqe.user_data());
 
     assert_eq!(cqes.len(), 2);
@@ -177,7 +177,7 @@ pub fn test_timeout_cancel(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<
     let timeout_e = opcode::Timeout::new(&ts);
 
     unsafe {
-        let mut queue = ring.submission().available();
+        let mut queue = ring.submission_mut();
         queue
             .push(&timeout_e.build().user_data(0x10))
             .expect("queue is full");
@@ -190,7 +190,7 @@ pub fn test_timeout_cancel(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<
     let timeout_e = opcode::AsyncCancel::new(0x10);
 
     unsafe {
-        let mut queue = ring.submission().available();
+        let mut queue = ring.submission_mut();
         queue
             .push(&timeout_e.build().user_data(0x11))
             .expect("queue is full");
@@ -201,7 +201,7 @@ pub fn test_timeout_cancel(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<
 
     assert_eq!(start.elapsed().as_secs(), 0);
 
-    let mut cqes = ring.completion().available().collect::<Vec<_>>();
+    let mut cqes = ring.completion_mut().collect::<Vec<_>>();
     cqes.sort_by_key(|cqe| cqe.user_data());
 
     assert_eq!(cqes.len(), 2);

--- a/io-uring-test/src/tests/timeout.rs
+++ b/io-uring-test/src/tests/timeout.rs
@@ -14,7 +14,7 @@ pub fn test_timeout(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()> {
     let timeout_e = opcode::Timeout::new(&ts);
 
     unsafe {
-        let mut queue = ring.submission_mut();
+        let mut queue = ring.submission();
         queue
             .push(&timeout_e.build().user_data(0x09))
             .expect("queue is full");
@@ -25,7 +25,7 @@ pub fn test_timeout(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()> {
 
     assert_eq!(start.elapsed().as_secs(), 1);
 
-    let cqes = ring.completion_mut().collect::<Vec<_>>();
+    let cqes = ring.completion().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x09);
@@ -38,7 +38,7 @@ pub fn test_timeout(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()> {
     let nop_e = opcode::Nop::new();
 
     unsafe {
-        let mut queue = ring.submission_mut();
+        let mut queue = ring.submission();
         queue
             .push(&timeout_e.build().user_data(0x0a))
             .expect("queue is full");
@@ -54,7 +54,7 @@ pub fn test_timeout(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()> {
 
     assert_eq!(start.elapsed().as_secs(), 0);
 
-    let cqes = ring.completion_mut().collect::<Vec<_>>();
+    let cqes = ring.completion().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x0b);
@@ -66,7 +66,7 @@ pub fn test_timeout(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()> {
 
     assert_eq!(start.elapsed().as_secs(), 1);
 
-    let cqes = ring.completion_mut().collect::<Vec<_>>();
+    let cqes = ring.completion().collect::<Vec<_>>();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x0a);
@@ -87,7 +87,7 @@ pub fn test_timeout_count(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<(
     let nop_e = opcode::Nop::new();
 
     unsafe {
-        let mut queue = ring.submission_mut();
+        let mut queue = ring.submission();
         queue
             .push(&timeout_e.build().user_data(0x0c))
             .expect("queue is full");
@@ -101,7 +101,7 @@ pub fn test_timeout_count(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<(
 
     assert_eq!(start.elapsed().as_secs(), 0);
 
-    let mut cqes = ring.completion_mut().collect::<Vec<_>>();
+    let mut cqes = ring.completion().collect::<Vec<_>>();
     cqes.sort_by_key(|cqe| cqe.user_data());
 
     assert_eq!(cqes.len(), 2);
@@ -127,7 +127,7 @@ pub fn test_timeout_remove(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<
     let timeout_e = opcode::Timeout::new(&ts);
 
     unsafe {
-        let mut queue = ring.submission_mut();
+        let mut queue = ring.submission();
         queue
             .push(&timeout_e.build().user_data(0x10))
             .expect("queue is full");
@@ -140,7 +140,7 @@ pub fn test_timeout_remove(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<
     let timeout_e = opcode::TimeoutRemove::new(0x10);
 
     unsafe {
-        let mut queue = ring.submission_mut();
+        let mut queue = ring.submission();
         queue
             .push(&timeout_e.build().user_data(0x11))
             .expect("queue is full");
@@ -151,7 +151,7 @@ pub fn test_timeout_remove(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<
 
     assert_eq!(start.elapsed().as_secs(), 0);
 
-    let mut cqes = ring.completion_mut().collect::<Vec<_>>();
+    let mut cqes = ring.completion().collect::<Vec<_>>();
     cqes.sort_by_key(|cqe| cqe.user_data());
 
     assert_eq!(cqes.len(), 2);
@@ -177,7 +177,7 @@ pub fn test_timeout_cancel(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<
     let timeout_e = opcode::Timeout::new(&ts);
 
     unsafe {
-        let mut queue = ring.submission_mut();
+        let mut queue = ring.submission();
         queue
             .push(&timeout_e.build().user_data(0x10))
             .expect("queue is full");
@@ -190,7 +190,7 @@ pub fn test_timeout_cancel(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<
     let timeout_e = opcode::AsyncCancel::new(0x10);
 
     unsafe {
-        let mut queue = ring.submission_mut();
+        let mut queue = ring.submission();
         queue
             .push(&timeout_e.build().user_data(0x11))
             .expect("queue is full");
@@ -201,7 +201,7 @@ pub fn test_timeout_cancel(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<
 
     assert_eq!(start.elapsed().as_secs(), 0);
 
-    let mut cqes = ring.completion_mut().collect::<Vec<_>>();
+    let mut cqes = ring.completion().collect::<Vec<_>>();
     cqes.sort_by_key(|cqe| cqe.user_data());
 
     assert_eq!(cqes.len(), 2);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,8 @@ use util::{Fd, Mmap};
 /// IoUring instance
 pub struct IoUring {
     inner: Inner,
-    sq: SubmissionQueue,
-    cq: CompletionQueue,
+    sq: squeue::Inner,
+    cq: cqueue::Inner,
 }
 
 struct Inner {
@@ -84,7 +84,7 @@ impl IoUring {
         unsafe fn setup_queue(
             fd: &Fd,
             p: &sys::io_uring_params,
-        ) -> io::Result<(MemoryMap, SubmissionQueue, CompletionQueue)> {
+        ) -> io::Result<(MemoryMap, squeue::Inner, cqueue::Inner)> {
             let sq_len = p.sq_off.array as usize + p.sq_entries as usize * mem::size_of::<u32>();
             let cq_len = p.cq_off.cqes as usize
                 + p.cq_entries as usize * mem::size_of::<sys::io_uring_cqe>();
@@ -95,8 +95,8 @@ impl IoUring {
                 let scq_mmap =
                     Mmap::new(fd, sys::IORING_OFF_SQ_RING as _, cmp::max(sq_len, cq_len))?;
 
-                let sq = SubmissionQueue::new(&scq_mmap, &sqe_mmap, p);
-                let cq = CompletionQueue::new(&scq_mmap, p);
+                let sq = squeue::Inner::new(&scq_mmap, &sqe_mmap, p);
+                let cq = cqueue::Inner::new(&scq_mmap, p);
                 let mm = MemoryMap {
                     sq_mmap: scq_mmap,
                     cq_mmap: None,
@@ -108,8 +108,8 @@ impl IoUring {
                 let sq_mmap = Mmap::new(fd, sys::IORING_OFF_SQ_RING as _, sq_len)?;
                 let cq_mmap = Mmap::new(fd, sys::IORING_OFF_CQ_RING as _, cq_len)?;
 
-                let sq = SubmissionQueue::new(&sq_mmap, &sqe_mmap, p);
-                let cq = CompletionQueue::new(&cq_mmap, p);
+                let sq = squeue::Inner::new(&sq_mmap, &sqe_mmap, p);
+                let cq = cqueue::Inner::new(&cq_mmap, p);
                 let mm = MemoryMap {
                     cq_mmap: Some(cq_mmap),
                     sq_mmap,
@@ -173,7 +173,7 @@ impl IoUring {
 
     /// Get the submitter, submission queue and completion queue of the io_uring instance. This can
     /// be used to operate on the different parts of the io_uring instance independently.
-    pub fn split(&mut self) -> (Submitter<'_>, squeue::Mut<'_>, cqueue::Mut<'_>) {
+    pub fn split(&mut self) -> (Submitter<'_>, SubmissionQueue<'_>, CompletionQueue<'_>) {
         let submit = Submitter::new(
             &self.inner.fd,
             &self.inner.params,
@@ -181,18 +181,18 @@ impl IoUring {
             self.sq.tail,
             self.sq.flags,
         );
-        (submit, squeue::Mut(&mut self.sq), cqueue::Mut(&mut self.cq))
+        (submit, self.sq.borrow(), self.cq.borrow())
     }
 
     /// Get the submission queue of the io_uring instance. This is used to send I/O requests to the
     /// kernel.
-    pub fn submission_mut(&mut self) -> squeue::Mut<'_> {
-        squeue::Mut(&mut self.sq)
+    pub fn submission(&mut self) -> SubmissionQueue<'_> {
+        self.sq.borrow()
     }
 
     /// Get completion queue. This is used to receive I/O completion events from the kernel.
-    pub fn completion_mut(&mut self) -> cqueue::Mut<'_> {
-        cqueue::Mut(&mut self.cq)
+    pub fn completion(&mut self) -> CompletionQueue<'_> {
+        self.cq.borrow()
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ impl IoUring {
 
     /// Get the submitter, submission queue and completion queue of the io_uring instance. This can
     /// be used to operate on the different parts of the io_uring instance independently.
-    pub fn split(&mut self) -> (Submitter<'_>, &mut SubmissionQueue, &mut CompletionQueue) {
+    pub fn split(&mut self) -> (Submitter<'_>, squeue::Mut<'_>, cqueue::Mut<'_>) {
         let submit = Submitter::new(
             &self.inner.fd,
             &self.inner.params,
@@ -181,18 +181,18 @@ impl IoUring {
             self.sq.tail,
             self.sq.flags,
         );
-        (submit, &mut self.sq, &mut self.cq)
+        (submit, squeue::Mut(&mut self.sq), cqueue::Mut(&mut self.cq))
     }
 
-    /// Get the submission queue of the io_uring instace. This is used to send I/O requests to the
+    /// Get the submission queue of the io_uring instance. This is used to send I/O requests to the
     /// kernel.
-    pub fn submission(&mut self) -> &mut SubmissionQueue {
-        &mut self.sq
+    pub fn submission_mut(&mut self) -> squeue::Mut<'_> {
+        squeue::Mut(&mut self.sq)
     }
 
     /// Get completion queue. This is used to receive I/O completion events from the kernel.
-    pub fn completion(&mut self) -> &mut CompletionQueue {
-        &mut self.cq
+    pub fn completion_mut(&mut self) -> cqueue::Mut<'_> {
+        cqueue::Mut(&mut self.cq)
     }
 
     #[inline]

--- a/src/ownedsplit.rs
+++ b/src/ownedsplit.rs
@@ -1,4 +1,4 @@
-use crate::{CompletionQueue, Inner, IoUring, SubmissionQueue, Submitter};
+use crate::{cqueue, squeue, CompletionQueue, Inner, IoUring, SubmissionQueue, Submitter};
 use std::sync::{atomic, Arc};
 
 #[derive(Clone)]
@@ -69,14 +69,14 @@ impl SubmitterUring {
 impl SubmissionUring {
     /// Get the submission queue of the io_uring instace. This is used to send I/O requests to the
     /// kernel.
-    pub fn submission(&mut self) -> &mut SubmissionQueue {
-        &mut self.sq
+    pub fn submission_mut(&mut self) -> squeue::Mut<'_> {
+        squeue::Mut(&mut self.sq)
     }
 }
 
 impl CompletionUring {
     /// Get completion queue. This is used to receive I/O completion events from the kernel.
-    pub fn completion(&mut self) -> &mut CompletionQueue {
-        &mut self.cq
+    pub fn completion_mut(&mut self) -> cqueue::Mut<'_> {
+        cqueue::Mut(&mut self.cq)
     }
 }

--- a/src/ownedsplit.rs
+++ b/src/ownedsplit.rs
@@ -12,12 +12,12 @@ pub struct SubmitterUring {
 
 pub struct SubmissionUring {
     _inner: Arc<Inner>,
-    sq: SubmissionQueue,
+    sq: squeue::Inner,
 }
 
 pub struct CompletionUring {
     _inner: Arc<Inner>,
-    cq: CompletionQueue,
+    cq: cqueue::Inner,
 }
 
 /// Safety: This only allows execution of syscall and atomic reads, so it is thread-safe.
@@ -69,14 +69,14 @@ impl SubmitterUring {
 impl SubmissionUring {
     /// Get the submission queue of the io_uring instace. This is used to send I/O requests to the
     /// kernel.
-    pub fn submission_mut(&mut self) -> squeue::Mut<'_> {
-        squeue::Mut(&mut self.sq)
+    pub fn submission(&mut self) -> SubmissionQueue<'_> {
+        self.sq.borrow()
     }
 }
 
 impl CompletionUring {
     /// Get completion queue. This is used to receive I/O completion events from the kernel.
-    pub fn completion_mut(&mut self) -> cqueue::Mut<'_> {
-        cqueue::Mut(&mut self.cq)
+    pub fn completion(&mut self) -> CompletionQueue<'_> {
+        self.cq.borrow()
     }
 }


### PR DESCRIPTION
Fixes #71 and #61.

- The name `Mut` is free to be changed, I chose it to be used with code like `cqueue::Mut`, but I'll admit it doesn't give very good docs and having two types of the same name can be confusing.
- I renamed `submission`/`completion` to `submission_mut`/`completion_mut` as they return `Mut`s, and also it would be nice to have methods that return `&SubmissionQueue`s and `&CompletionQueue`s in the future.
- `Mut::reborrow` is free to be changed, as an alternative it could be called `as_mut`.
- I also removed `AvailableQueue` in favour of using the atomic ops directly, since they're cheap.