### PR TITLE
Return slice from CompletionQueue::fill

### DIFF
--- a/io-uring-bench/src/iai_new_nop.rs
+++ b/io-uring-bench/src/iai_new_nop.rs
@@ -60,9 +60,9 @@ fn bench_io_uring_batch() {
 
         io_uring.submit_and_wait(N).unwrap();
 
-        let n = io_uring.completion().fill(&mut cqes);
+        let init_cqes = io_uring.completion().fill(&mut cqes);
 
-        assert_eq!(n, N);
+        assert_eq!(init_cqes.len(), N);
 
         cqes.iter().map(black_box).for_each(drop);
     }

--- a/io-uring-test/src/tests/queue.rs
+++ b/io-uring-test/src/tests/queue.rs
@@ -55,13 +55,11 @@ pub fn test_batch(ring: &mut IoUring, _probe: &Probe) -> anyhow::Result<()> {
 
     let mut cqes = (0..10).map(|_| MaybeUninit::uninit()).collect::<Vec<_>>();
 
-    let n = ring.completion().fill(&mut cqes);
+    let cqes = ring.completion().fill(&mut cqes);
 
-    assert_eq!(n, 8);
+    assert_eq!(cqes.len(), 8);
 
-    for entry in cqes.into_iter().take(8) {
-        let entry = unsafe { entry.assume_init() };
-
+    for entry in cqes {
         assert_eq!(entry.user_data(), 0x09);
     }
 

--- a/src/cqueue.rs
+++ b/src/cqueue.rs
@@ -139,16 +139,16 @@ impl CompletionQueue<'_> {
     #[cfg(feature = "unstable")]
     #[inline]
     pub fn fill<'a>(&mut self, entries: &'a mut [MaybeUninit<Entry>]) -> &'a mut [Entry] {
-        let len = std::cmp::min(self.len(), entries.len()) as u32;
+        let len = std::cmp::min(self.len(), entries.len());
 
-        for entry in &mut entries[..len as usize] {
+        for entry in &mut entries[..len] {
             *entry = MaybeUninit::new(Entry(unsafe {
                 *self.queue.cqes.add((self.head & self.ring_mask) as usize)
             }));
             self.head = self.head.wrapping_add(1);
         }
 
-        unsafe { std::slice::from_raw_parts_mut(entries as *mut _ as *mut Entry, len as usize) }
+        unsafe { std::slice::from_raw_parts_mut(entries as *mut _ as *mut Entry, len) }
     }
 }
 


### PR DESCRIPTION
This is slightly more helpful to the user, it reduces the amount of `unsafe` they have to use.