### PR TITLE
Fix more warnings

### DIFF
--- a/io-uring-test/src/tests/poll.rs
+++ b/io-uring-test/src/tests/poll.rs
@@ -35,7 +35,7 @@ pub fn test_eventfd_poll(ring: &mut IoUring, probe: &Probe) -> anyhow::Result<()
     thread::sleep(Duration::from_millis(200));
     assert_eq!(ring.completion().len(), 0);
 
-    fd.write(&0x1u64.to_ne_bytes())?;
+    fd.write_all(&0x1u64.to_ne_bytes())?;
     ring.submit_and_wait(1)?;
 
     let cqes = ring.completion().collect::<Vec<_>>();
@@ -93,7 +93,7 @@ pub fn test_eventfd_poll_remove(ring: &mut IoUring, probe: &Probe) -> anyhow::Re
 
     thread::sleep(Duration::from_millis(200));
 
-    fd.write(&0x1u64.to_ne_bytes())?;
+    fd.write_all(&0x1u64.to_ne_bytes())?;
     ring.submit_and_wait(2)?;
 
     let mut cqes = ring.completion().collect::<Vec<_>>();
@@ -137,7 +137,7 @@ pub fn test_eventfd_poll_remove_failed(ring: &mut IoUring, probe: &Probe) -> any
             .expect("queue is full");
     }
 
-    fd.write(&0x1u64.to_ne_bytes())?;
+    fd.write_all(&0x1u64.to_ne_bytes())?;
     ring.submit_and_wait(1)?;
     assert_eq!(ring.completion().len(), 1);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! The crate only provides a summary of the parameters.
 //! For more detailed documentation, see manpage.
+#![warn(rust_2018_idioms, unused_qualifications)]
 
 #[macro_use]
 mod util;
@@ -10,6 +11,7 @@ pub mod opcode;
 mod register;
 pub mod squeue;
 mod submit;
+#[allow(warnings)]
 mod sys;
 pub mod types;
 

--- a/src/squeue.rs
+++ b/src/squeue.rs
@@ -217,7 +217,7 @@ impl SubmissionQueue<'_> {
     }
 
     /// Attempts to push an [`Entry`] into the queue.
-    /// If the queue is full, the element is returned back as an error.
+    /// If the queue is full, an error is returned.
     ///
     /// # Safety
     ///
@@ -237,6 +237,14 @@ impl SubmissionQueue<'_> {
         }
     }
 
+    /// Attempts to push several [entries](Entry) into the queue.
+    /// If the queue does not have space for all of the entries, an error is returned.
+    ///
+    /// # Safety
+    ///
+    /// Developers must ensure that parameters of all the entries (such as buffer) are valid and
+    /// will be valid for the entire duration of the operation, otherwise it may cause memory
+    /// problems.
     #[cfg(feature = "unstable")]
     #[inline]
     pub unsafe fn push_multiple(&mut self, entries: &[Entry]) -> Result<(), PushError> {

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -132,7 +132,11 @@ impl<'a> Submitter<'a> {
     }
 
     #[cfg(feature = "unstable")]
-    pub fn submit_with_args(&self, want: usize, args: &types::SubmitArgs) -> io::Result<usize> {
+    pub fn submit_with_args(
+        &self,
+        want: usize,
+        args: &types::SubmitArgs<'_, '_>,
+    ) -> io::Result<usize> {
         let len = self.sq_len();
         let mut flags = sys::IORING_ENTER_EXT_ARG;
 


### PR DESCRIPTION
This fixes Clippy warnings, as well as enabling `rust_2018_idioms` and `unused_qualifications` which are warnings I quite like.