### PR TITLE
Add unsafe {submission, completion}_shared APIs

### DIFF
--- a/src/cqueue.rs
+++ b/src/cqueue.rs
@@ -56,14 +56,17 @@ impl Inner {
     }
 
     #[inline]
-    pub(crate) fn borrow(&mut self) -> CompletionQueue<'_> {
-        unsafe {
-            CompletionQueue {
-                head: unsync_load(self.head),
-                tail: (*self.tail).load(atomic::Ordering::Acquire),
-                queue: self,
-            }
+    pub(crate) unsafe fn borrow_shared(&self) -> CompletionQueue<'_> {
+        CompletionQueue {
+            head: unsync_load(self.head),
+            tail: (*self.tail).load(atomic::Ordering::Acquire),
+            queue: self,
         }
+    }
+
+    #[inline]
+    pub(crate) fn borrow(&mut self) -> CompletionQueue<'_> {
+        unsafe { self.borrow_shared() }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,12 +29,8 @@ use util::{Fd, Mmap};
 
 /// IoUring instance
 pub struct IoUring {
-    inner: Inner,
     sq: squeue::Inner,
     cq: cqueue::Inner,
-}
-
-struct Inner {
     fd: Fd,
     params: Parameters,
     memory: ManuallyDrop<MemoryMap>,
@@ -129,13 +125,11 @@ impl IoUring {
         let (mm, sq, cq) = unsafe { setup_queue(&fd, &p)? };
 
         Ok(IoUring {
-            inner: Inner {
-                fd,
-                params: Parameters(p),
-                memory: ManuallyDrop::new(mm),
-            },
             sq,
             cq,
+            fd,
+            params: Parameters(p),
+            memory: ManuallyDrop::new(mm),
         })
     }
 
@@ -144,8 +138,8 @@ impl IoUring {
     #[inline]
     pub fn submitter(&self) -> Submitter<'_> {
         Submitter::new(
-            &self.inner.fd,
-            &self.inner.params,
+            &self.fd,
+            &self.params,
             self.sq.head,
             self.sq.tail,
             self.sq.flags,
@@ -155,7 +149,7 @@ impl IoUring {
     /// Get the parameters that were used to construct this instance.
     #[inline]
     pub fn params(&self) -> &Parameters {
-        &self.inner.params
+        &self.params
     }
 
     /// Initiate asynchronous I/O. See [`Submitter::submit`] for more details.
@@ -176,8 +170,8 @@ impl IoUring {
     #[inline]
     pub fn split(&mut self) -> (Submitter<'_>, SubmissionQueue<'_>, CompletionQueue<'_>) {
         let submit = Submitter::new(
-            &self.inner.fd,
-            &self.inner.params,
+            &self.fd,
+            &self.params,
             self.sq.head,
             self.sq.tail,
             self.sq.flags,
@@ -192,10 +186,31 @@ impl IoUring {
         self.sq.borrow()
     }
 
-    /// Get completion queue. This is used to receive I/O completion events from the kernel.
+    /// Get the submission queue of the io_uring instance from a shared reference.
+    ///
+    /// # Safety
+    ///
+    /// No other [`SubmissionQueue`]s may exist when calling this function.
+    #[inline]
+    pub unsafe fn submission_shared(&self) -> SubmissionQueue<'_> {
+        self.sq.borrow_shared()
+    }
+
+    /// Get completion queue of the io_uring instance. This is used to receive I/O completion
+    /// events from the kernel.
     #[inline]
     pub fn completion(&mut self) -> CompletionQueue<'_> {
         self.cq.borrow()
+    }
+
+    /// Get the completion queue of the io_uring instance from a shared reference.
+    ///
+    /// # Safety
+    ///
+    /// No other [`CompletionQueue`]s may exist when calling this function.
+    #[inline]
+    pub unsafe fn completion_shared(&self) -> CompletionQueue<'_> {
+        self.cq.borrow_shared()
     }
 
     #[inline]
@@ -211,7 +226,7 @@ impl IoUring {
     }
 }
 
-impl Drop for Inner {
+impl Drop for IoUring {
     fn drop(&mut self) {
         // Ensure that `MemoryMap` is released before `fd`.
         unsafe {
@@ -304,9 +319,9 @@ impl Builder {
         let ring = IoUring::with_params(entries, self.params)?;
 
         if self.dontfork {
-            ring.inner.memory.sq_mmap.dontfork()?;
-            ring.inner.memory.sqe_mmap.dontfork()?;
-            if let Some(cq_mmap) = ring.inner.memory.cq_mmap.as_ref() {
+            ring.memory.sq_mmap.dontfork()?;
+            ring.memory.sqe_mmap.dontfork()?;
+            if let Some(cq_mmap) = ring.memory.cq_mmap.as_ref() {
                 cq_mmap.dontfork()?;
             }
         }
@@ -411,6 +426,6 @@ impl Parameters {
 
 impl AsRawFd for IoUring {
     fn as_raw_fd(&self) -> RawFd {
-        self.inner.fd.as_raw_fd()
+        self.fd.as_raw_fd()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,7 @@ impl IoUring {
     ///
     /// No other [`SubmissionQueue`]s may exist when calling this function.
     #[inline]
+    #[cfg(feature = "unstable")]
     pub unsafe fn submission_shared(&self) -> SubmissionQueue<'_> {
         self.sq.borrow_shared()
     }
@@ -209,6 +210,7 @@ impl IoUring {
     ///
     /// No other [`CompletionQueue`]s may exist when calling this function.
     #[inline]
+    #[cfg(feature = "unstable")]
     pub unsafe fn completion_shared(&self) -> CompletionQueue<'_> {
         self.cq.borrow_shared()
     }

--- a/src/squeue.rs
+++ b/src/squeue.rs
@@ -128,14 +128,17 @@ impl Inner {
     }
 
     #[inline]
-    pub(crate) fn borrow(&mut self) -> SubmissionQueue<'_> {
-        unsafe {
-            SubmissionQueue {
-                head: (*self.head).load(atomic::Ordering::Acquire),
-                tail: unsync_load(self.tail),
-                queue: self,
-            }
+    pub(crate) unsafe fn borrow_shared(&self) -> SubmissionQueue<'_> {
+        SubmissionQueue {
+            head: (*self.head).load(atomic::Ordering::Acquire),
+            tail: unsync_load(self.tail),
+            queue: self,
         }
+    }
+
+    #[inline]
+    pub(crate) fn borrow(&mut self) -> SubmissionQueue<'_> {
+        unsafe { self.borrow_shared() }
     }
 }
 


### PR DESCRIPTION
This allows `ownedsplit` to be implemented using only the public API of the library.