### PR TITLE
Warn missing debug implementations

### DIFF
--- a/src/cqueue.rs
+++ b/src/cqueue.rs
@@ -1,5 +1,6 @@
 //! Completion Queue
 
+use std::fmt::{self, Debug, Formatter};
 #[cfg(feature = "unstable")]
 use std::mem::MaybeUninit;
 use std::sync::atomic;
@@ -22,6 +23,7 @@ pub(crate) struct Inner {
 }
 
 /// An io_uring instance's completion queue. This stores all the I/O operations that have completed.
+#[derive(Debug)]
 pub struct CompletionQueue<'a> {
     head: u32,
     tail: u32,
@@ -67,6 +69,20 @@ impl Inner {
     #[inline]
     pub(crate) fn borrow(&mut self) -> CompletionQueue<'_> {
         unsafe { self.borrow_shared() }
+    }
+}
+
+impl Debug for Inner {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CompletionQueueInner")
+            .field("head", unsafe { &*self.head })
+            .field("tail", unsafe { &*self.tail })
+            .field("ring_mask", &self.ring_mask)
+            .field("ring_entries", &self.ring_entries)
+            .field("flags", unsafe { &*self.flags })
+            .field("overflow", unsafe { &*self.overflow })
+            .field("cqes", &self.cqes)
+            .finish()
     }
 }
 
@@ -215,6 +231,16 @@ impl Entry {
     #[inline]
     pub fn flags(&self) -> u32 {
         self.0.flags
+    }
+}
+
+impl Debug for Entry {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Entry")
+            .field("result", &self.0.res)
+            .field("user_data", &self.0.user_data)
+            .field("flags", &self.0.flags)
+            .finish()
     }
 }
 

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -502,6 +502,7 @@ opcode!(
 
 opcode!(
     /// Attempt to remove an existing [timeout operation](Timeout).
+    #[derive(Debug)]
     pub struct TimeoutRemove {
         user_data: { u64 },
         ;;
@@ -524,6 +525,7 @@ opcode!(
 
 opcode!(
     /// Accept a new connection on a socket, equivalent to `accept4(2)`.
+    #[derive(Debug)]
     pub struct Accept {
         fd: { impl sealed::UseFixed },
         addr: { *mut libc::sockaddr },
@@ -549,6 +551,7 @@ opcode!(
 
 opcode!(
     /// Attempt to cancel an already issued request.
+    #[derive(Debug)]
     pub struct AsyncCancel {
         user_data: { u64 }
         ;;
@@ -573,6 +576,7 @@ opcode!(
     /// This request must be linked with another request through
     /// [`Flags::IO_LINK`](crate::squeue::Flags::IO_LINK) which is described below.
     /// Unlike [`Timeout`], [`LinkTimeout`] acts on the linked request, not the completion queue.
+    #[derive(Debug)]
     pub struct LinkTimeout {
         timespec: { *const types::Timespec },
         ;;
@@ -596,6 +600,7 @@ opcode!(
 
 opcode!(
     /// Connect a socket, equivalent to `connect(2)`.
+    #[derive(Debug)]
     pub struct Connect {
         fd: { impl sealed::UseFixed },
         addr: { *const libc::sockaddr },
@@ -621,6 +626,7 @@ opcode!(
 
 opcode!(
     /// Preallocate or deallocate space to a file, equivalent to `fallocate(2)`.
+    #[derive(Debug)]
     pub struct Fallocate {
         fd: { impl sealed::UseFixed },
         len: { libc::off_t },
@@ -646,6 +652,7 @@ opcode!(
 
 opcode!(
     /// Open a file, equivalent to `openat(2)`.
+    #[derive(Debug)]
     pub struct OpenAt {
         dirfd: { impl sealed::UseFd },
         pathname: { *const libc::c_char },
@@ -671,6 +678,7 @@ opcode!(
 
 opcode!(
     /// Close a file descriptor, equivalent to `close(2)`.
+    #[derive(Debug)]
     pub struct Close {
         fd: { impl sealed::UseFd }
         ;;
@@ -692,6 +700,7 @@ opcode!(
     /// This command is an alternative to using
     /// [`Submitter::register_files_update`](crate::Submitter::register_files_update) which then
     /// works in an async fashion, like the rest of the io_uring commands.
+    #[derive(Debug)]
     pub struct FilesUpdate {
         fds: { *const RawFd },
         len: { u32 },
@@ -716,6 +725,7 @@ opcode!(
 
 opcode!(
     /// Get file status, equivalent to `statx(2)`.
+    #[derive(Debug)]
     pub struct Statx {
         dirfd: { impl sealed::UseFd },
         pathname: { *const libc::c_char },
@@ -746,6 +756,7 @@ opcode!(
 
 opcode!(
     /// Read from a file descriptor, equivalent to `read(2)`.
+    #[derive(Debug)]
     pub struct Read {
         fd: { impl sealed::UseFixed },
         buf: { *mut u8 },
@@ -782,6 +793,7 @@ opcode!(
 
 opcode!(
     /// Write to a file descriptor, equivalent to `write(2)`.
+    #[derive(Debug)]
     pub struct Write {
         fd: { impl sealed::UseFixed },
         buf: { *const u8 },
@@ -815,6 +827,7 @@ opcode!(
 
 opcode!(
     /// Predeclare an access pattern for file data, equivalent to `posix_fadvise(2)`.
+    #[derive(Debug)]
     pub struct Fadvise {
         fd: { impl sealed::UseFixed },
         len: { libc::off_t },
@@ -840,6 +853,7 @@ opcode!(
 
 opcode!(
     /// Give advice about use of memory, equivalent to `madvise(2)`.
+    #[derive(Debug)]
     pub struct Madvise {
         addr: { *const libc::c_void },
         len: { libc::off_t },
@@ -864,6 +878,7 @@ opcode!(
 
 opcode!(
     /// Send a message on a socket, equivalent to `send(2)`.
+    #[derive(Debug)]
     pub struct Send {
         fd: { impl sealed::UseFixed },
         buf: { *const u8 },
@@ -889,6 +904,7 @@ opcode!(
 
 opcode!(
     /// Receive a message from a socket, equivalent to `recv(2)`.
+    #[derive(Debug)]
     pub struct Recv {
         fd: { impl sealed::UseFixed },
         buf: { *mut u8 },
@@ -916,6 +932,7 @@ opcode!(
 
 opcode!(
     /// Open a file, equivalent to `openat2(2)`.
+    #[derive(Debug)]
     pub struct OpenAt2 {
         dirfd: { impl sealed::UseFd },
         pathname: { *const libc::c_char },
@@ -940,6 +957,7 @@ opcode!(
 
 opcode!(
     /// Modify an epoll file descriptor, equivalent to `epoll_ctl(2)`.
+    #[derive(Debug)]
     pub struct EpollCtl {
         epfd: { impl sealed::UseFixed },
         fd: { impl sealed::UseFd },
@@ -970,6 +988,7 @@ opcode!(
     /// Splice data to/from a pipe, equivalent to `splice(2)`.
     ///
     /// Requires the `unstable` feature.
+    #[derive(Debug)]
     pub struct Splice {
         fd_in: { impl sealed::UseFixed },
         off_in: { i64 },
@@ -1012,6 +1031,7 @@ opcode!(
     /// [`BUFFER_SELECT`](crate::squeue::Flags::BUFFER_SELECT) for more info.
     ///
     /// Requires the `unstable` feature.
+    #[derive(Debug)]
     pub struct ProvideBuffers {
         addr: { *mut u8 },
         len: { i32 },
@@ -1043,6 +1063,7 @@ opcode!(
     /// [`BUFFER_SELECT`](crate::squeue::Flags::BUFFER_SELECT) for more info.
     ///
     /// Requires the `unstable` feature.
+    #[derive(Debug)]
     pub struct RemoveBuffers {
         nbufs: { u16 },
         bgid: { u16 }
@@ -1069,6 +1090,7 @@ opcode!(
     /// Duplicate pipe content, equivalent to `tee(2)`.
     ///
     /// Requires the `unstable` feature.
+    #[derive(Debug)]
     pub struct Tee {
         fd_in: { impl sealed::UseFixed },
         fd_out: { impl sealed::UseFixed },
@@ -1106,6 +1128,7 @@ opcode!(
 
 #[cfg(feature = "unstable")]
 opcode!(
+    #[derive(Debug)]
     pub struct Shutdown {
         fd: { impl sealed::UseFixed },
         how: { i32 },
@@ -1127,6 +1150,7 @@ opcode!(
 
 #[cfg(feature = "unstable")]
 opcode!(
+    #[derive(Debug)]
     pub struct RenameAt {
         olddirfd: { impl sealed::UseFd },
         oldpath: { *const libc::c_char },
@@ -1158,6 +1182,7 @@ opcode!(
 
 #[cfg(feature = "unstable")]
 opcode!(
+    #[derive(Debug)]
     pub struct UnlinkAt {
         dirfd: { impl sealed::UseFd },
         pathname: { *const libc::c_char },

--- a/src/ownedsplit.rs
+++ b/src/ownedsplit.rs
@@ -1,13 +1,15 @@
 use crate::{CompletionQueue, IoUring, SubmissionQueue, Submitter};
 use std::sync::Arc;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct SubmitterUring {
     inner: Arc<IoUring>,
 }
+#[derive(Debug)]
 pub struct SubmissionUring {
     inner: Arc<IoUring>,
 }
+#[derive(Debug)]
 pub struct CompletionUring {
     inner: Arc<IoUring>,
 }

--- a/src/squeue.rs
+++ b/src/squeue.rs
@@ -1,7 +1,7 @@
 //! Submission Queue
 
 use std::error::Error;
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Debug, Display, Formatter};
 use std::sync::atomic;
 
 use crate::sys;
@@ -21,6 +21,7 @@ pub(crate) struct Inner {
 }
 
 /// An io_uring instance's submission queue. This is used to send I/O requests to the kernel.
+#[derive(Debug)]
 pub struct SubmissionQueue<'a> {
     head: u32,
     tail: u32,
@@ -139,6 +140,20 @@ impl Inner {
     #[inline]
     pub(crate) fn borrow(&mut self) -> SubmissionQueue<'_> {
         unsafe { self.borrow_shared() }
+    }
+}
+
+impl Debug for Inner {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SubmissionQueueInner")
+            .field("head", unsafe { &*self.head })
+            .field("tail", unsafe { &*self.tail })
+            .field("ring_mask", &self.ring_mask)
+            .field("ring_entries", &self.ring_entries)
+            .field("flags", unsafe { &*self.flags })
+            .field("dropped", unsafe { &*self.dropped })
+            .field("sqes", &self.sqes)
+            .finish()
     }
 }
 
@@ -298,6 +313,20 @@ impl Entry {
     pub fn personality(mut self, personality: u16) -> Entry {
         self.0.__bindgen_anon_4.__bindgen_anon_1.personality = personality;
         self
+    }
+}
+
+impl Debug for Entry {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Entry")
+            .field("opcode", &self.0.opcode)
+            .field("fd", &self.0.fd)
+            .field("flags", &Flags::from_bits(self.0.flags).unwrap())
+            .field("user_data", &self.0.user_data)
+            .field("personality", unsafe {
+                &self.0.__bindgen_anon_4.__bindgen_anon_1.personality
+            })
+            .finish()
     }
 }
 

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -1,3 +1,4 @@
+use std::fmt::{self, Debug, Formatter};
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::atomic;
 use std::{io, ptr};
@@ -371,5 +372,17 @@ impl<'a> Submitter<'a> {
             0,
         )
         .map(drop)
+    }
+}
+
+impl Debug for Submitter<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Submitter")
+            .field("fd", self.fd)
+            .field("params", self.params)
+            .field("sq_head", unsafe { &*self.sq_head })
+            .field("sq_tail", unsafe { &*self.sq_tail })
+            .field("sq_flags", unsafe { &*self.sq_flags })
+            .finish()
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -54,12 +54,14 @@ pub use sys::__kernel_rwf_t as RwFlags;
 
 /// Opaque types, you should use [`statx`](struct@libc::statx) instead.
 #[repr(C)]
+#[allow(missing_debug_implementations)]
 pub struct statx {
     _priv: (),
 }
 
 /// Opaque types, you should use [`epoll_event`](libc::epoll_event) instead.
 #[repr(C)]
+#[allow(missing_debug_implementations)]
 pub struct epoll_event {
     _priv: (),
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,6 +4,7 @@ use std::sync::atomic;
 use std::{io, mem, ptr};
 
 /// A region of memory mapped using `mmap(2)`.
+#[derive(Debug)]
 pub struct Mmap {
     addr: ptr::NonNull<libc::c_void>,
     len: usize,
@@ -61,6 +62,7 @@ impl Drop for Mmap {
 }
 
 /// An owned file descriptor.
+#[derive(Debug)]
 pub struct Fd(pub RawFd);
 
 impl TryFrom<RawFd> for Fd {


### PR DESCRIPTION
This adds `#![warn(missing_debug_implementations)]` to the crate root, and implements `Debug` for lots of types.