### PR TITLE
Remove reborrow on sq and cq

### DIFF
--- a/examples/tcp_echo.rs
+++ b/examples/tcp_echo.rs
@@ -38,7 +38,7 @@ impl AcceptCount {
         }
     }
 
-    pub fn push_to(&mut self, mut sq: SubmissionQueue<'_>) {
+    pub fn push_to(&mut self, sq: &mut SubmissionQueue<'_>) {
         while self.count > 0 {
             unsafe {
                 match sq.push(&self.entry) {
@@ -65,7 +65,7 @@ fn main() -> anyhow::Result<()> {
 
     let mut accept = AcceptCount::new(listener.as_raw_fd(), token_alloc.insert(Token::Accept), 3);
 
-    accept.push_to(sq.reborrow());
+    accept.push_to(&mut sq);
 
     loop {
         match submitter.submit_and_wait(1) {
@@ -97,9 +97,9 @@ fn main() -> anyhow::Result<()> {
 
         drop(iter);
 
-        accept.push_to(sq.reborrow());
+        accept.push_to(&mut sq);
 
-        for cqe in cq.reborrow() {
+        for cqe in &mut cq {
             let ret = cqe.result();
             let token_index = cqe.user_data() as usize;
 

--- a/src/cqueue.rs
+++ b/src/cqueue.rs
@@ -71,19 +71,6 @@ impl Inner {
 }
 
 impl CompletionQueue<'_> {
-    /// Reborrow this queue to a shorter lifetime.
-    ///
-    /// This can be used to avoid consuming the `CompletionQueue` when passing it to functions.
-    #[must_use]
-    #[inline]
-    pub fn reborrow(&mut self) -> CompletionQueue<'_> {
-        CompletionQueue {
-            head: self.head,
-            tail: self.tail,
-            queue: self.queue,
-        }
-    }
-
     /// Synchronize this type with the real completion queue.
     ///
     /// This will flush any entries consumed in this iterator and will make available new entries

--- a/src/squeue.rs
+++ b/src/squeue.rs
@@ -143,19 +143,6 @@ impl Inner {
 }
 
 impl SubmissionQueue<'_> {
-    /// Reborrow this queue to a shorter lifetime.
-    ///
-    /// This can be used to avoid consuming the `SubmissionQueue` when passing it to functions.
-    #[must_use]
-    #[inline]
-    pub fn reborrow(&mut self) -> SubmissionQueue<'_> {
-        SubmissionQueue {
-            head: self.head,
-            tail: self.tail,
-            queue: self.queue,
-        }
-    }
-
     /// Synchronize this type with the real submission queue.
     ///
     /// This will flush any entries added by [`push`](Self::push) or


### PR DESCRIPTION
Because this method copies over the head/tail to a new queue, the original queue becomes outdated and useless, and pushing to it might result in overwriting sqes or at worst reading into uninitialized memory.