### PR TITLE
Update cross kernel

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,5 @@
 [target.x86_64-unknown-linux-gnu]
-image = "quininer/cross-nk:x86_64-unknown-linux-gnu-0.0.2"
+image = "quininer/cross-nk:x86_64-unknown-linux-gnu-0.0.3"
 runner = "qemu-system"
 
 [target.aarch64-unknown-linux-gnu]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,7 +1,7 @@
 [target.x86_64-unknown-linux-gnu]
-image = "quininer/cross-nk:x86_64-unknown-linux-gnu-0.0.3"
+image = "quininer/cross-nk:x86_64-unknown-linux-gnu-0.0.4"
 runner = "qemu-system"
 
 [target.aarch64-unknown-linux-gnu]
-image = "quininer/cross-nk:aarch64-unknown-linux-gnu-0.0.2"
+image = "quininer/cross-nk:aarch64-unknown-linux-gnu-0.0.4"
 runner = "qemu-system"


### PR DESCRIPTION
debian buster has not released the 5.10 kernel of arm64, I will try to update to bullseye.