### PR TITLE
Change raw pointers to references

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ fn main() -> io::Result<()> {
     let mut ring = IoUring::new(8)?;
 
     let fd = fs::File::open("README.md")?;
-    let mut buf = vec![0; 1024];
+    let mut buf = vec![0; 16];
 
     let read_e = opcode::Read::new(types::Fd(fd.as_raw_fd()), buf.as_mut_ptr(), buf.len() as _)
         .build()
@@ -48,6 +48,7 @@ fn main() -> io::Result<()> {
 
     assert_eq!(cqe.user_data(), 0x42);
     assert!(cqe.result() >= 0, "read error: {}", cqe.result());
+    assert_eq!(&buf[..], b"# Linux IO Uring");
 
     Ok(())
 }

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ fn main() -> io::Result<()> {
     let fd = fs::File::open("README.md")?;
     let mut buf = vec![0; 16];
 
-    let read_e = opcode::Read::new(types::Fd(fd.as_raw_fd()), buf.as_mut_ptr(), buf.len() as _)
+    let read_e = opcode::Read::new(types::Fd(fd.as_raw_fd()), &mut buf)
         .build()
         .user_data(0x42);
 

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -6,7 +6,7 @@ fn main() -> io::Result<()> {
     let mut ring = IoUring::new(8)?;
 
     let fd = fs::File::open("README.md")?;
-    let mut buf = vec![0; 1024];
+    let mut buf = vec![0; 16];
 
     let read_e = opcode::Read::new(types::Fd(fd.as_raw_fd()), buf.as_mut_ptr(), buf.len() as _)
         .build()
@@ -26,6 +26,7 @@ fn main() -> io::Result<()> {
 
     assert_eq!(cqe.user_data(), 0x42);
     assert!(cqe.result() >= 0, "read error: {}", cqe.result());
+    assert_eq!(&buf[..], b"# Linux IO Uring");
 
     Ok(())
 }

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -8,7 +8,7 @@ fn main() -> io::Result<()> {
     let fd = fs::File::open("README.md")?;
     let mut buf = vec![0; 16];
 
-    let read_e = opcode::Read::new(types::Fd(fd.as_raw_fd()), buf.as_mut_ptr(), buf.len() as _)
+    let read_e = opcode::Read::new(types::Fd(fd.as_raw_fd()), &mut buf)
         .build()
         .user_data(0x42);
 

--- a/examples/readv.rs
+++ b/examples/readv.rs
@@ -1,0 +1,36 @@
+use io_uring::{opcode, types, IoUring};
+use std::io::IoSliceMut;
+use std::os::unix::io::AsRawFd;
+use std::{fs, io};
+
+fn main() -> io::Result<()> {
+    let mut ring = IoUring::new(8)?;
+
+    let fd = fs::File::open("README.md")?;
+
+    let mut buf1 = [1; 4];
+    let mut buf2 = [2; 8];
+    let bufs = &mut [IoSliceMut::new(&mut buf1), IoSliceMut::new(&mut buf2)][..];
+
+    let readv_e = opcode::Readv::new(types::Fd(fd.as_raw_fd()), bufs)
+        .build()
+        .user_data(0x42);
+
+    // Note that the developer needs to ensure
+    // that the entry pushed into submission queue is valid (e.g. fd, buffer).
+    unsafe {
+        ring.submission()
+            .push(&readv_e)
+            .expect("submission queue is full");
+    }
+
+    ring.submit_and_wait(1)?;
+
+    let cqe = ring.completion().next().expect("completion queue is empty");
+
+    assert_eq!(cqe.user_data(), 0x42);
+    assert!(cqe.result() >= 0, "read error: {}", cqe.result());
+    assert_eq!(&buf1[..], b"# Li");
+
+    Ok(())
+}

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -746,10 +746,9 @@ opcode!(
 
 opcode!(
     /// Read from a file descriptor, equivalent to `read(2)`.
-    pub struct Read {
+    pub struct Read<'a> {
         fd: { impl sealed::UseFixed },
-        buf: { *mut u8 },
-        len: { u32 },
+        buf: { &'a mut [u8] },
         ;;
         offset: libc::off_t = 0,
         ioprio: u16 = 0,
@@ -762,7 +761,7 @@ opcode!(
     pub fn build(self) -> Entry {
         let Read {
             fd,
-            buf, len, offset,
+            buf, offset,
             ioprio, rw_flags,
             buf_group
         } = self;
@@ -771,8 +770,8 @@ opcode!(
         sqe.opcode = Self::CODE;
         assign_fd!(sqe.fd = fd);
         sqe.ioprio = ioprio;
-        sqe.__bindgen_anon_2.addr = buf as _;
-        sqe.len = len;
+        sqe.__bindgen_anon_2.addr = buf.as_mut_ptr() as _;
+        sqe.len = buf.len().try_into().unwrap();
         sqe.__bindgen_anon_1.off = offset as _;
         sqe.__bindgen_anon_3.rw_flags = rw_flags;
         sqe.__bindgen_anon_4.buf_group = buf_group;

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -862,10 +862,9 @@ opcode!(
 
 opcode!(
     /// Send a message on a socket, equivalent to `send(2)`.
-    pub struct Send {
+    pub struct Send<'a> {
         fd: { impl sealed::UseFixed },
-        buf: { *const u8 },
-        len: { u32 },
+        buf: { &'a [u8] },
         ;;
         flags: i32 = 0
     }
@@ -873,13 +872,13 @@ opcode!(
     pub const CODE = sys::IORING_OP_SEND;
 
     pub fn build(self) -> Entry {
-        let Send { fd, buf, len, flags } = self;
+        let Send { fd, buf, flags } = self;
 
         let mut sqe = sqe_zeroed();
         sqe.opcode = Self::CODE;
         assign_fd!(sqe.fd = fd);
-        sqe.__bindgen_anon_2.addr = buf as _;
-        sqe.len = len;
+        sqe.__bindgen_anon_2.addr = buf.as_ptr() as _;
+        sqe.len = buf.len().try_into().unwrap();
         sqe.__bindgen_anon_3.msg_flags = flags as _;
         Entry(sqe)
     }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -781,10 +781,9 @@ opcode!(
 
 opcode!(
     /// Write to a file descriptor, equivalent to `write(2)`.
-    pub struct Write {
+    pub struct Write<'a> {
         fd: { impl sealed::UseFixed },
-        buf: { *const u8 },
-        len: { u32 },
+        buf: { &'a [u8] },
         ;;
         offset: libc::off_t = 0,
         ioprio: u16 = 0,
@@ -796,7 +795,7 @@ opcode!(
     pub fn build(self) -> Entry {
         let Write {
             fd,
-            buf, len, offset,
+            buf, offset,
             ioprio, rw_flags
         } = self;
 
@@ -804,8 +803,8 @@ opcode!(
         sqe.opcode = Self::CODE;
         assign_fd!(sqe.fd = fd);
         sqe.ioprio = ioprio;
-        sqe.__bindgen_anon_2.addr = buf as _;
-        sqe.len = len;
+        sqe.__bindgen_anon_2.addr = buf.as_ptr() as _;
+        sqe.len = buf.len().try_into().unwrap();
         sqe.__bindgen_anon_1.off = offset as _;
         sqe.__bindgen_anon_3.rw_flags = rw_flags;
         Entry(sqe)

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -887,10 +887,9 @@ opcode!(
 
 opcode!(
     /// Receive a message from a socket, equivalent to `recv(2)`.
-    pub struct Recv {
+    pub struct Recv<'a> {
         fd: { impl sealed::UseFixed },
-        buf: { *mut u8 },
-        len: { u32 },
+        buf: { &'a mut [u8] },
         ;;
         flags: i32 = 0,
         buf_group: u16 = 0
@@ -899,13 +898,13 @@ opcode!(
     pub const CODE = sys::IORING_OP_RECV;
 
     pub fn build(self) -> Entry {
-        let Recv { fd, buf, len, flags, buf_group } = self;
+        let Recv { fd, buf, flags, buf_group } = self;
 
         let mut sqe = sqe_zeroed();
         sqe.opcode = Self::CODE;
         assign_fd!(sqe.fd = fd);
-        sqe.__bindgen_anon_2.addr = buf as _;
-        sqe.len = len;
+        sqe.__bindgen_anon_2.addr = buf.as_mut_ptr() as _;
+        sqe.len = buf.len().try_into().unwrap();
         sqe.__bindgen_anon_3.msg_flags = flags as _;
         sqe.__bindgen_anon_4.buf_group = buf_group;
         Entry(sqe)


### PR DESCRIPTION
I am changing the Opcode structs to be more rust like by changing the raw pointers to references.

This is a step to make it more secure by using the borrow checker of rust.