### PR TITLE
Add new Linux 5.15 opcodes

### DIFF
--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1179,3 +1179,87 @@ opcode!(
         Entry(sqe)
     }
 );
+
+// === 5.15 ===
+
+#[cfg(feature = "unstable")]
+opcode!(
+    /// Make a directory, equivalent to `mkdirat2(2)`.
+    ///
+    /// Requires the `unstable` feature.
+    pub struct MkDirAt {
+        dirfd: { impl sealed::UseFd },
+        pathname: { *const libc::c_char },
+        ;;
+        mode: libc::mode_t = 0
+    }
+
+    pub const CODE = sys::IORING_OP_MKDIRAT;
+
+    pub fn build(self) -> Entry {
+        let MkDirAt { dirfd, pathname, mode } = self;
+
+        let mut sqe = sqe_zeroed();
+        sqe.opcode = Self::CODE;
+        sqe.fd = dirfd;
+        sqe.__bindgen_anon_2.addr = pathname as _;
+        sqe.len = mode;
+        Entry(sqe)
+    }
+);
+
+#[cfg(feature = "unstable")]
+opcode!(
+    /// Create a symlink, equivalent to `symlinkat2(2)`.
+    ///
+    /// Requires the `unstable` feature.
+    pub struct SymlinkAt {
+        newdirfd: { impl sealed::UseFd },
+        target: { *const libc::c_char },
+        linkpath: { *const libc::c_char },
+        ;;
+    }
+
+    pub const CODE = sys::IORING_OP_SYMLINKAT;
+
+    pub fn build(self) -> Entry {
+        let SymlinkAt { newdirfd, target, linkpath } = self;
+
+        let mut sqe = sqe_zeroed();
+        sqe.opcode = Self::CODE;
+        sqe.fd = newdirfd;
+        sqe.__bindgen_anon_2.addr = target as _;
+        sqe.__bindgen_anon_1.addr2 = linkpath as _;
+        Entry(sqe)
+    }
+);
+
+#[cfg(feature = "unstable")]
+opcode!(
+    /// Create a hard link, equivalent to `linkat2(2)`.
+    ///
+    /// Requires the `unstable` feature.
+    pub struct LinkAt {
+        olddirfd: { impl sealed::UseFd },
+        oldpath: { *const libc::c_char },
+        newdirfd: { impl sealed::UseFd },
+        newpath: { *const libc::c_char },
+        ;;
+        flags: i32 = 0
+    }
+
+    pub const CODE = sys::IORING_OP_LINKAT;
+
+    pub fn build(self) -> Entry {
+        let LinkAt { olddirfd, oldpath, newdirfd, newpath, flags } = self;
+
+        let mut sqe = sqe_zeroed();
+        sqe.opcode = Self::CODE;
+        sqe.fd = olddirfd as _;
+        sqe.__bindgen_anon_2.addr = oldpath as _;
+        sqe.len = newdirfd as _;
+        sqe.__bindgen_anon_1.addr2 = newpath as _;
+        sqe.__bindgen_anon_3.hardlink_flags = flags as _;
+        Entry(sqe)
+    }
+);

--- a/src/sys/sys.rs
+++ b/src/sys/sys.rs
@@ -306,6 +306,7 @@ pub union io_uring_sqe__bindgen_ty_3 {
     pub splice_flags: __u32,
     pub rename_flags: __u32,
     pub unlink_flags: __u32,
+    pub hardlink_flags: __u32,
 }
 #[test]
 fn bindgen_test_layout_io_uring_sqe__bindgen_ty_3() {
@@ -726,7 +727,10 @@ pub const IORING_OP_TEE: libc::c_uint = 33;
 pub const IORING_OP_SHUTDOWN: libc::c_uint = 34;
 pub const IORING_OP_RENAMEAT: libc::c_uint = 35;
 pub const IORING_OP_UNLINKAT: libc::c_uint = 36;
-pub const IORING_OP_LAST: libc::c_uint = 37;
+pub const IORING_OP_MKDIRAT: libc::c_uint = 37;
+pub const IORING_OP_SYMLINKAT: libc::c_uint = 38;
+pub const IORING_OP_LINKAT: libc::c_uint = 39;
+pub const IORING_OP_LAST: libc::c_uint = 40;
 pub type _bindgen_ty_5 = libc::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]


### PR DESCRIPTION
IORING_OP_MKDIRAT, IORING_OP_SYMLINKAT, and IORING_OP_LINKAT

Addresses #94.

I'm not 100% I did this right. Also, liburing says these were added in Liun 5.15 which isn't out yet?