### PR TITLE
Allow debug printing of the submission queue

### DIFF
--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -28,6 +28,7 @@ fn main() -> anyhow::Result<()> {
 
     tests::queue::test_nop(&mut ring, &test)?;
     tests::queue::test_queue_split(&mut ring, &test)?;
+    tests::queue::test_debug_print(&mut ring, &test)?;
 
     #[cfg(feature = "unstable")]
     tests::queue::test_batch(&mut ring, &test)?;


### PR DESCRIPTION
When debugging programs using io_uring it can be useful to check the
state of the submission queue. To make that easier I've added an
implementation of Debug on Entry and SubmissionQueue.

I'm not 100% sure I implemented this correctly so I'd appreciate a code review. I also added a test that just prints the queue full and then empty. I'm not sure if a different or more comprehensive testing method is desired.