### PR TITLE
opcode: use u64 type for the offset

### DIFF
--- a/io-uring-test/src/tests/fs.rs
+++ b/io-uring-test/src/tests/fs.rs
@@ -561,7 +561,7 @@ pub fn test_file_cur_pos<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     let mut output = vec![0; text.len()];
 
     let write_e = opcode::Write::new(fd, text.as_ptr(), 22)
-        .offset(-1)
+        .offset(u64::MAX)
         .build()
         .user_data(0x01)
         .into();
@@ -573,7 +573,7 @@ pub fn test_file_cur_pos<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     ring.submit_and_wait(1)?;
 
     let write_e = opcode::Write::new(fd, unsafe { text.as_ptr().add(22) }, 22)
-        .offset(-1)
+        .offset(u64::MAX)
         .build()
         .user_data(0x02)
         .into();

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -129,7 +129,7 @@ opcode!(
         len: { u32 },
         ;;
         ioprio: u16 = 0,
-        offset64: libc::off64_t = 0,
+        offset: u64 = 0,
         /// specified for read operations, contains a bitwise OR of per-I/O flags,
         /// as described in the `preadv2(2)` man page.
         rw_flags: types::RwFlags = 0,
@@ -141,7 +141,7 @@ opcode!(
     pub fn build(self) -> Entry {
         let Readv {
             fd,
-            iovec, len, offset64,
+            iovec, len, offset,
             ioprio, rw_flags,
             buf_group
         } = self;
@@ -152,19 +152,12 @@ opcode!(
         sqe.ioprio = ioprio;
         sqe.__bindgen_anon_2.addr = iovec as _;
         sqe.len = len;
-        sqe.__bindgen_anon_1.off = offset64 as _;
+        sqe.__bindgen_anon_1.off = offset;
         sqe.__bindgen_anon_3.rw_flags = rw_flags;
         sqe.__bindgen_anon_4.buf_group = buf_group;
         Entry(sqe)
     }
 );
-
-impl Readv {
-    #[inline]
-    pub const fn offset(self, offset: libc::off_t) -> Self {
-        self.offset64(offset as libc::off64_t)
-    }
-}
 
 opcode!(
     /// Vectored write, equivalent to `pwritev2(2)`.
@@ -175,7 +168,7 @@ opcode!(
         len: { u32 },
         ;;
         ioprio: u16 = 0,
-        offset64: libc::off64_t = 0,
+        offset: u64 = 0,
         /// specified for write operations, contains a bitwise OR of per-I/O flags,
         /// as described in the `preadv2(2)` man page.
         rw_flags: types::RwFlags = 0
@@ -186,7 +179,7 @@ opcode!(
     pub fn build(self) -> Entry {
         let Writev {
             fd,
-            iovec, len, offset64,
+            iovec, len, offset,
             ioprio, rw_flags
         } = self;
 
@@ -196,18 +189,11 @@ opcode!(
         sqe.ioprio = ioprio;
         sqe.__bindgen_anon_2.addr = iovec as _;
         sqe.len = len;
-        sqe.__bindgen_anon_1.off = offset64 as _;
+        sqe.__bindgen_anon_1.off = offset;
         sqe.__bindgen_anon_3.rw_flags = rw_flags;
         Entry(sqe)
     }
 );
-
-impl Writev {
-    #[inline]
-    pub const fn offset(self, offset: libc::off_t) -> Self {
-        self.offset64(offset as libc::off64_t)
-    }
-}
 
 opcode!(
     /// File sync, equivalent to `fsync(2)`.
@@ -255,7 +241,7 @@ opcode!(
         len: { u32 },
         buf_index: { u16 },
         ;;
-        offset64: libc::off64_t = 0,
+        offset: u64 = 0,
         ioprio: u16 = 0,
         /// specified for read operations, contains a bitwise OR of per-I/O flags,
         /// as described in the `preadv2(2)` man page.
@@ -267,7 +253,7 @@ opcode!(
     pub fn build(self) -> Entry {
         let ReadFixed {
             fd,
-            buf, len, offset64,
+            buf, len, offset,
             buf_index,
             ioprio, rw_flags
         } = self;
@@ -278,19 +264,12 @@ opcode!(
         sqe.ioprio = ioprio;
         sqe.__bindgen_anon_2.addr = buf as _;
         sqe.len = len;
-        sqe.__bindgen_anon_1.off = offset64 as _;
+        sqe.__bindgen_anon_1.off = offset;
         sqe.__bindgen_anon_3.rw_flags = rw_flags;
         sqe.__bindgen_anon_4.buf_index = buf_index;
         Entry(sqe)
     }
 );
-
-impl ReadFixed {
-    #[inline]
-    pub const fn offset(self, offset: libc::off_t) -> Self {
-        self.offset64(offset as libc::off64_t)
-    }
-}
 
 opcode!(
     /// Write to pre-mapped buffers that have been previously registered with
@@ -307,7 +286,7 @@ opcode!(
         buf_index: { u16 },
         ;;
         ioprio: u16 = 0,
-        offset64: libc::off64_t = 0,
+        offset: u64 = 0,
         /// specified for write operations, contains a bitwise OR of per-I/O flags,
         /// as described in the `preadv2(2)` man page.
         rw_flags: types::RwFlags = 0
@@ -318,7 +297,7 @@ opcode!(
     pub fn build(self) -> Entry {
         let WriteFixed {
             fd,
-            buf, len, offset64,
+            buf, len, offset,
             buf_index,
             ioprio, rw_flags
         } = self;
@@ -329,19 +308,12 @@ opcode!(
         sqe.ioprio = ioprio;
         sqe.__bindgen_anon_2.addr = buf as _;
         sqe.len = len;
-        sqe.__bindgen_anon_1.off = offset64 as _;
+        sqe.__bindgen_anon_1.off = offset;
         sqe.__bindgen_anon_3.rw_flags = rw_flags;
         sqe.__bindgen_anon_4.buf_index = buf_index;
         Entry(sqe)
     }
 );
-
-impl WriteFixed {
-    #[inline]
-    pub const fn offset(self, offset: libc::off_t) -> Self {
-        self.offset64(offset as libc::off64_t)
-    }
-}
 
 opcode!(
     /// Poll the specified fd.
@@ -424,7 +396,7 @@ opcode!(
         len: { u32 },
         ;;
         /// the offset method holds the offset in bytes
-        offset: libc::off64_t = 0,
+        offset: u64 = 0,
         /// the flags method holds the flags for the command
         flags: u32 = 0
     }
@@ -442,7 +414,7 @@ opcode!(
         sqe.opcode = Self::CODE;
         assign_fd!(sqe.fd = fd);
         sqe.len = len as _;
-        sqe.__bindgen_anon_1.off = offset as _;
+        sqe.__bindgen_anon_1.off = offset;
         sqe.__bindgen_anon_3.sync_range_flags = flags;
         Entry(sqe)
     }
@@ -759,32 +731,24 @@ opcode!(
         fd: { impl sealed::UseFixed },
         len: { libc::off_t },
         ;;
-        offset64: libc::off64_t = 0,
+        offset: u64 = 0,
         mode: i32 = 0
     }
 
     pub const CODE = sys::IORING_OP_FALLOCATE;
 
     pub fn build(self) -> Entry {
-        let Fallocate { fd, len, offset64, mode } = self;
+        let Fallocate { fd, len, offset, mode } = self;
 
         let mut sqe = sqe_zeroed();
         sqe.opcode = Self::CODE;
         assign_fd!(sqe.fd = fd);
         sqe.__bindgen_anon_2.addr = len as _;
         sqe.len = mode as _;
-        sqe.__bindgen_anon_1.off = offset64 as _;
+        sqe.__bindgen_anon_1.off = offset;
         Entry(sqe)
     }
 );
-
-#[allow(deprecated)]
-impl Fallocate {
-    #[inline]
-    pub const fn offset(self, offset: libc::off_t) -> Self {
-        self.offset64(offset as libc::off64_t)
-    }
-}
 
 opcode!(
     /// Preallocate or deallocate space to a file, equivalent to `fallocate(2)`.
@@ -792,31 +756,24 @@ opcode!(
         fd: { impl sealed::UseFixed },
         len: { libc::off64_t },
         ;;
-        offset64: libc::off64_t = 0,
+        offset: u64 = 0,
         mode: i32 = 0
     }
 
     pub const CODE = sys::IORING_OP_FALLOCATE;
 
     pub fn build(self) -> Entry {
-        let Fallocate64 { fd, len, offset64, mode } = self;
+        let Fallocate64 { fd, len, offset, mode } = self;
 
         let mut sqe = sqe_zeroed();
         sqe.opcode = Self::CODE;
         assign_fd!(sqe.fd = fd);
         sqe.__bindgen_anon_2.addr = len as _;
         sqe.len = mode as _;
-        sqe.__bindgen_anon_1.off = offset64 as _;
+        sqe.__bindgen_anon_1.off = offset;
         Entry(sqe)
     }
 );
-
-impl Fallocate64 {
-    #[inline]
-    pub const fn offset(self, offset: libc::off_t) -> Self {
-        self.offset64(offset as libc::off64_t)
-    }
-}
 
 opcode!(
     /// Open a file, equivalent to `openat(2)`.
@@ -951,7 +908,7 @@ opcode!(
         /// If `fd` does not refer to a seekable file, `offset` must be set to zero.
         /// If `offsett` is set to `-1`, the offset will use (and advance) the file position,
         /// like the `read(2)` and `write(2)` system calls.
-        offset64: libc::off64_t = 0,
+        offset: u64 = 0,
         ioprio: u16 = 0,
         rw_flags: types::RwFlags = 0,
         buf_group: u16 = 0
@@ -962,7 +919,7 @@ opcode!(
     pub fn build(self) -> Entry {
         let Read {
             fd,
-            buf, len, offset64,
+            buf, len, offset,
             ioprio, rw_flags,
             buf_group
         } = self;
@@ -973,19 +930,12 @@ opcode!(
         sqe.ioprio = ioprio;
         sqe.__bindgen_anon_2.addr = buf as _;
         sqe.len = len;
-        sqe.__bindgen_anon_1.off = offset64 as _;
+        sqe.__bindgen_anon_1.off = offset;
         sqe.__bindgen_anon_3.rw_flags = rw_flags;
         sqe.__bindgen_anon_4.buf_group = buf_group;
         Entry(sqe)
     }
 );
-
-impl Read {
-    #[inline]
-    pub const fn offset(self, offset: libc::off_t) -> Self {
-        self.offset64(offset as libc::off64_t)
-    }
-}
 
 opcode!(
     /// Issue the equivalent of a `pread(2)` or `pwrite(2)` system call
@@ -1008,7 +958,7 @@ opcode!(
         /// If `fd` does not refer to a seekable file, `offset` must be set to zero.
         /// If `offsett` is set to `-1`, the offset will use (and advance) the file position,
         /// like the `read(2)` and `write(2)` system calls.
-        offset64: libc::off64_t = 0,
+        offset: u64 = 0,
         ioprio: u16 = 0,
         rw_flags: types::RwFlags = 0
     }
@@ -1018,7 +968,7 @@ opcode!(
     pub fn build(self) -> Entry {
         let Write {
             fd,
-            buf, len, offset64,
+            buf, len, offset,
             ioprio, rw_flags
         } = self;
 
@@ -1028,18 +978,11 @@ opcode!(
         sqe.ioprio = ioprio;
         sqe.__bindgen_anon_2.addr = buf as _;
         sqe.len = len;
-        sqe.__bindgen_anon_1.off = offset64 as _;
+        sqe.__bindgen_anon_1.off = offset;
         sqe.__bindgen_anon_3.rw_flags = rw_flags;
         Entry(sqe)
     }
 );
-
-impl Write {
-    #[inline]
-    pub const fn offset(self, offset: libc::off_t) -> Self {
-        self.offset64(offset as libc::off64_t)
-    }
-}
 
 opcode!(
     /// Predeclare an access pattern for file data, equivalent to `posix_fadvise(2)`.
@@ -1048,30 +991,23 @@ opcode!(
         len: { libc::off_t },
         advice: { i32 },
         ;;
-        offset64: libc::off64_t = 0,
+        offset: u64 = 0,
     }
 
     pub const CODE = sys::IORING_OP_FADVISE;
 
     pub fn build(self) -> Entry {
-        let Fadvise { fd, len, advice, offset64 } = self;
+        let Fadvise { fd, len, advice, offset } = self;
 
         let mut sqe = sqe_zeroed();
         sqe.opcode = Self::CODE;
         assign_fd!(sqe.fd = fd);
         sqe.len = len as _;
-        sqe.__bindgen_anon_1.off = offset64 as _;
+        sqe.__bindgen_anon_1.off = offset;
         sqe.__bindgen_anon_3.fadvise_advice = advice as _;
         Entry(sqe)
     }
 );
-
-impl Fadvise {
-    #[inline]
-    pub const fn offset(self, offset: libc::off_t) -> Self {
-        self.offset64(offset as libc::off64_t)
-    }
-}
 
 opcode!(
     /// Give advice about use of memory, equivalent to `madvise(2)`.


### PR DESCRIPTION
`libc::off_t` is `i64` while kernel and liburing uses an `u64`
for the `offset` field in most of the opcodes.

There are some exceptions like `IORING_OP_FILES_UPDATE` and
`IORING_OP_FALLOCATE`.

To avoid differences and casting issues (e.g. using `try_into()`
on `u64` to cast to `i64` can fail) we should follow what liburing
does and expose offset as `u64`.

Fixes: #126
Signed-off-by: Stefano Garzarella <sgarzare@redhat.com>