### PR TITLE
Add UringCmd opcode

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -24,6 +24,7 @@ fn main() {
     bindgen::Builder::default()
         .header_contents("include-file.h", INCLUDE)
         .ctypes_prefix("libc")
+        .prepend_enum_name(false)
         .derive_default(true)
         .generate_comments(true)
         .use_core()

--- a/io-uring-test/src/tests/poll.rs
+++ b/io-uring-test/src/tests/poll.rs
@@ -1,12 +1,15 @@
 use crate::Test;
-use io_uring::{opcode, types, IoUring};
+use io_uring::{cqueue, opcode, squeue, types, IoUring};
 use std::fs::File;
 use std::io::{self, Write};
 use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::thread;
 use std::time::Duration;
 
-pub fn test_eventfd_poll(ring: &mut IoUring, test: &Test) -> anyhow::Result<()> {
+pub fn test_eventfd_poll<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
     require!(
         test;
         test.probe.is_supported(opcode::PollAdd::CODE);
@@ -29,7 +32,7 @@ pub fn test_eventfd_poll(ring: &mut IoUring, test: &Test) -> anyhow::Result<()> 
     unsafe {
         let mut queue = ring.submission();
         queue
-            .push(&poll_e.build().user_data(0x04))
+            .push(&poll_e.build().user_data(0x04).into())
             .expect("queue is full");
     }
 
@@ -40,7 +43,7 @@ pub fn test_eventfd_poll(ring: &mut IoUring, test: &Test) -> anyhow::Result<()> 
     fd.write_all(&0x1u64.to_ne_bytes())?;
     ring.submit_and_wait(1)?;
 
-    let cqes = ring.completion().collect::<Vec<_>>();
+    let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x04);
@@ -49,7 +52,10 @@ pub fn test_eventfd_poll(ring: &mut IoUring, test: &Test) -> anyhow::Result<()> 
     Ok(())
 }
 
-pub fn test_eventfd_poll_remove(ring: &mut IoUring, test: &Test) -> anyhow::Result<()> {
+pub fn test_eventfd_poll_remove<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
     require!(
         test;
         test.probe.is_supported(opcode::PollAdd::CODE);
@@ -75,7 +81,7 @@ pub fn test_eventfd_poll_remove(ring: &mut IoUring, test: &Test) -> anyhow::Resu
     unsafe {
         let mut queue = ring.submission();
         queue
-            .push(&poll_e.build().user_data(0x05))
+            .push(&poll_e.build().user_data(0x05).into())
             .expect("queue is full");
     }
 
@@ -88,7 +94,7 @@ pub fn test_eventfd_poll_remove(ring: &mut IoUring, test: &Test) -> anyhow::Resu
     unsafe {
         let mut queue = ring.submission();
         queue
-            .push(&poll_e.build().user_data(0x06))
+            .push(&poll_e.build().user_data(0x06).into())
             .expect("queue is full");
     }
 
@@ -99,7 +105,7 @@ pub fn test_eventfd_poll_remove(ring: &mut IoUring, test: &Test) -> anyhow::Resu
     fd.write_all(&0x1u64.to_ne_bytes())?;
     ring.submit_and_wait(2)?;
 
-    let mut cqes = ring.completion().collect::<Vec<_>>();
+    let mut cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
     cqes.sort_by_key(|cqe| cqe.user_data());
 
     assert_eq!(cqes.len(), 2);
@@ -111,7 +117,10 @@ pub fn test_eventfd_poll_remove(ring: &mut IoUring, test: &Test) -> anyhow::Resu
     Ok(())
 }
 
-pub fn test_eventfd_poll_remove_failed(ring: &mut IoUring, test: &Test) -> anyhow::Result<()> {
+pub fn test_eventfd_poll_remove_failed<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
     require!(
         test;
         test.probe.is_supported(opcode::PollAdd::CODE);
@@ -137,7 +146,7 @@ pub fn test_eventfd_poll_remove_failed(ring: &mut IoUring, test: &Test) -> anyho
     unsafe {
         let mut queue = ring.submission();
         queue
-            .push(&poll_e.build().user_data(0x07))
+            .push(&poll_e.build().user_data(0x07).into())
             .expect("queue is full");
     }
 
@@ -152,13 +161,13 @@ pub fn test_eventfd_poll_remove_failed(ring: &mut IoUring, test: &Test) -> anyho
     unsafe {
         let mut queue = ring.submission();
         queue
-            .push(&poll_e.build().user_data(0x08))
+            .push(&poll_e.build().user_data(0x08).into())
             .expect("queue is full");
     }
 
     ring.submit_and_wait(2)?;
 
-    let mut cqes = ring.completion().collect::<Vec<_>>();
+    let mut cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
     cqes.sort_by_key(|cqe| cqe.user_data());
 
     assert_eq!(cqes.len(), 2);

--- a/io-uring-test/src/tests/timeout.rs
+++ b/io-uring-test/src/tests/timeout.rs
@@ -1,8 +1,11 @@
 use crate::Test;
-use io_uring::{opcode, types, IoUring};
+use io_uring::{cqueue, opcode, squeue, types, IoUring};
 use std::time::Instant;
 
-pub fn test_timeout(ring: &mut IoUring, test: &Test) -> anyhow::Result<()> {
+pub fn test_timeout<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
     require!(
         test;
         test.probe.is_supported(opcode::Timeout::CODE);
@@ -18,7 +21,7 @@ pub fn test_timeout(ring: &mut IoUring, test: &Test) -> anyhow::Result<()> {
     unsafe {
         let mut queue = ring.submission();
         queue
-            .push(&timeout_e.build().user_data(0x09))
+            .push(&timeout_e.build().user_data(0x09).into())
             .expect("queue is full");
     }
 
@@ -27,7 +30,7 @@ pub fn test_timeout(ring: &mut IoUring, test: &Test) -> anyhow::Result<()> {
 
     assert_eq!(start.elapsed().as_secs(), 1);
 
-    let cqes = ring.completion().collect::<Vec<_>>();
+    let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x09);
@@ -42,10 +45,10 @@ pub fn test_timeout(ring: &mut IoUring, test: &Test) -> anyhow::Result<()> {
     unsafe {
         let mut queue = ring.submission();
         queue
-            .push(&timeout_e.build().user_data(0x0a))
+            .push(&timeout_e.build().user_data(0x0a).into())
             .expect("queue is full");
         queue
-            .push(&nop_e.build().user_data(0x0b))
+            .push(&nop_e.build().user_data(0x0b).into())
             .expect("queue is full");
     }
 
@@ -56,7 +59,7 @@ pub fn test_timeout(ring: &mut IoUring, test: &Test) -> anyhow::Result<()> {
 
     assert_eq!(start.elapsed().as_secs(), 0);
 
-    let cqes = ring.completion().collect::<Vec<_>>();
+    let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x0b);
@@ -68,7 +71,7 @@ pub fn test_timeout(ring: &mut IoUring, test: &Test) -> anyhow::Result<()> {
 
     assert_eq!(start.elapsed().as_secs(), 1);
 
-    let cqes = ring.completion().collect::<Vec<_>>();
+    let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x0a);
@@ -77,7 +80,10 @@ pub fn test_timeout(ring: &mut IoUring, test: &Test) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub fn test_timeout_count(ring: &mut IoUring, test: &Test) -> anyhow::Result<()> {
+pub fn test_timeout_count<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
     require!(
         test;
         test.probe.is_supported(opcode::Timeout::CODE);
@@ -92,10 +98,10 @@ pub fn test_timeout_count(ring: &mut IoUring, test: &Test) -> anyhow::Result<()>
     unsafe {
         let mut queue = ring.submission();
         queue
-            .push(&timeout_e.build().user_data(0x0c))
+            .push(&timeout_e.build().user_data(0x0c).into())
             .expect("queue is full");
         queue
-            .push(&nop_e.build().user_data(0x0d))
+            .push(&nop_e.build().user_data(0x0d).into())
             .expect("queue is full");
     }
 
@@ -104,7 +110,7 @@ pub fn test_timeout_count(ring: &mut IoUring, test: &Test) -> anyhow::Result<()>
 
     assert_eq!(start.elapsed().as_secs(), 0);
 
-    let mut cqes = ring.completion().collect::<Vec<_>>();
+    let mut cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
     cqes.sort_by_key(|cqe| cqe.user_data());
 
     assert_eq!(cqes.len(), 2);
@@ -116,7 +122,10 @@ pub fn test_timeout_count(ring: &mut IoUring, test: &Test) -> anyhow::Result<()>
     Ok(())
 }
 
-pub fn test_timeout_remove(ring: &mut IoUring, test: &Test) -> anyhow::Result<()> {
+pub fn test_timeout_remove<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
     require!(
         test;
         test.probe.is_supported(opcode::Timeout::CODE);
@@ -133,7 +142,7 @@ pub fn test_timeout_remove(ring: &mut IoUring, test: &Test) -> anyhow::Result<()
     unsafe {
         let mut queue = ring.submission();
         queue
-            .push(&timeout_e.build().user_data(0x10))
+            .push(&timeout_e.build().user_data(0x10).into())
             .expect("queue is full");
     }
 
@@ -146,7 +155,7 @@ pub fn test_timeout_remove(ring: &mut IoUring, test: &Test) -> anyhow::Result<()
     unsafe {
         let mut queue = ring.submission();
         queue
-            .push(&timeout_e.build().user_data(0x11))
+            .push(&timeout_e.build().user_data(0x11).into())
             .expect("queue is full");
     }
 
@@ -155,7 +164,7 @@ pub fn test_timeout_remove(ring: &mut IoUring, test: &Test) -> anyhow::Result<()
 
     assert_eq!(start.elapsed().as_secs(), 0);
 
-    let mut cqes = ring.completion().collect::<Vec<_>>();
+    let mut cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
     cqes.sort_by_key(|cqe| cqe.user_data());
 
     assert_eq!(cqes.len(), 2);
@@ -167,7 +176,10 @@ pub fn test_timeout_remove(ring: &mut IoUring, test: &Test) -> anyhow::Result<()
     Ok(())
 }
 
-pub fn test_timeout_cancel(ring: &mut IoUring, test: &Test) -> anyhow::Result<()> {
+pub fn test_timeout_cancel<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
     require!(
         test;
         test.probe.is_supported(opcode::Timeout::CODE);
@@ -184,7 +196,7 @@ pub fn test_timeout_cancel(ring: &mut IoUring, test: &Test) -> anyhow::Result<()
     unsafe {
         let mut queue = ring.submission();
         queue
-            .push(&timeout_e.build().user_data(0x10))
+            .push(&timeout_e.build().user_data(0x10).into())
             .expect("queue is full");
     }
 
@@ -197,7 +209,7 @@ pub fn test_timeout_cancel(ring: &mut IoUring, test: &Test) -> anyhow::Result<()
     unsafe {
         let mut queue = ring.submission();
         queue
-            .push(&timeout_e.build().user_data(0x11))
+            .push(&timeout_e.build().user_data(0x11).into())
             .expect("queue is full");
     }
 
@@ -206,7 +218,7 @@ pub fn test_timeout_cancel(ring: &mut IoUring, test: &Test) -> anyhow::Result<()
 
     assert_eq!(start.elapsed().as_secs(), 0);
 
-    let mut cqes = ring.completion().collect::<Vec<_>>();
+    let mut cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
     cqes.sort_by_key(|cqe| cqe.user_data());
 
     assert_eq!(cqes.len(), 2);
@@ -218,7 +230,10 @@ pub fn test_timeout_cancel(ring: &mut IoUring, test: &Test) -> anyhow::Result<()
     Ok(())
 }
 
-pub fn test_timeout_abs(ring: &mut IoUring, test: &Test) -> anyhow::Result<()> {
+pub fn test_timeout_abs<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
     require!(
         test;
         test.probe.is_supported(opcode::Timeout::CODE);
@@ -244,7 +259,7 @@ pub fn test_timeout_abs(ring: &mut IoUring, test: &Test) -> anyhow::Result<()> {
     unsafe {
         let mut queue = ring.submission();
         queue
-            .push(&timeout_e.build().user_data(0x19))
+            .push(&timeout_e.build().user_data(0x19).into())
             .expect("queue is full");
     }
 
@@ -253,7 +268,7 @@ pub fn test_timeout_abs(ring: &mut IoUring, test: &Test) -> anyhow::Result<()> {
 
     assert!(start.elapsed().as_secs() >= 1);
 
-    let cqes = ring.completion().collect::<Vec<_>>();
+    let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x19);
@@ -263,7 +278,10 @@ pub fn test_timeout_abs(ring: &mut IoUring, test: &Test) -> anyhow::Result<()> {
 }
 
 #[cfg(feature = "unstable")]
-pub fn test_timeout_submit_args(ring: &mut IoUring, test: &Test) -> anyhow::Result<()> {
+pub fn test_timeout_submit_args<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
     require! {
         test;
         ring.params().is_feature_ext_arg();
@@ -294,7 +312,7 @@ pub fn test_timeout_submit_args(ring: &mut IoUring, test: &Test) -> anyhow::Resu
 
     unsafe {
         ring.submission()
-            .push(&nop_e.build().user_data(0x1c))
+            .push(&nop_e.build().user_data(0x1c).into())
             .expect("queue is full");
     }
 
@@ -302,7 +320,7 @@ pub fn test_timeout_submit_args(ring: &mut IoUring, test: &Test) -> anyhow::Resu
     ring.submitter().submit_with_args(1, &args)?;
     assert_eq!(start.elapsed().as_secs(), 0);
 
-    let cqes = ring.completion().collect::<Vec<_>>();
+    let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
 
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x1c);

--- a/src/cqueue.rs
+++ b/src/cqueue.rs
@@ -1,14 +1,15 @@
 //! Completion Queue
 
+use std::fmt::{self, Debug};
+use std::mem;
 #[cfg(feature = "unstable")]
 use std::mem::MaybeUninit;
 use std::sync::atomic;
-use std::{fmt, mem};
 
 use crate::sys;
 use crate::util::{unsync_load, Mmap};
 
-pub(crate) struct Inner {
+pub(crate) struct Inner<E: EntryMarker> {
     head: *const atomic::AtomicU32,
     tail: *const atomic::AtomicU32,
     ring_mask: u32,
@@ -16,24 +17,51 @@ pub(crate) struct Inner {
 
     overflow: *const atomic::AtomicU32,
 
-    cqes: *const sys::io_uring_cqe,
+    cqes: *const E,
 
     #[allow(dead_code)]
     flags: *const atomic::AtomicU32,
 }
 
 /// An io_uring instance's completion queue. This stores all the I/O operations that have completed.
-pub struct CompletionQueue<'a> {
+pub struct CompletionQueue<'a, E: EntryMarker = Entry> {
     head: u32,
     tail: u32,
-    queue: &'a Inner,
+    queue: &'a Inner<E>,
 }
 
-/// An entry in the completion queue, representing a complete I/O operation.
-#[repr(transparent)]
+pub(crate) use private::Sealed;
+mod private {
+    /// Private trait that we use as a supertrait of `EntryMarker` to prevent it from being
+    /// implemented from outside this crate: https://jack.wrenn.fyi/blog/private-trait-methods/
+    pub trait Sealed {
+        const ADDITIONAL_FLAGS: u32;
+    }
+}
+
+/// A completion queue entry (CQE), representing a complete I/O operation.
+///
+/// This is implemented for [`Entry`] and [`Entry32`].
+pub trait EntryMarker: Clone + Debug + Into<Entry> + Sealed {}
+
+/// A 16-byte completion queue entry (CQE), representing a complete I/O operation.
+#[repr(C)]
 pub struct Entry(pub(crate) sys::io_uring_cqe);
 
-impl Inner {
+/// A 32-byte completion queue entry (CQE), representing a complete I/O operation.
+#[cfg(feature = "unstable")]
+#[repr(C)]
+#[derive(Clone)]
+pub struct Entry32(pub(crate) Entry, pub(crate) [u64; 2]);
+
+#[test]
+fn test_entry_sizes() {
+    assert_eq!(mem::size_of::<Entry>(), 16);
+    #[cfg(feature = "unstable")]
+    assert_eq!(mem::size_of::<Entry32>(), 32);
+}
+
+impl<E: EntryMarker> Inner<E> {
     #[rustfmt::skip]
     pub(crate) unsafe fn new(cq_mmap: &Mmap, p: &sys::io_uring_params) -> Self {
         let head         = cq_mmap.offset(p.cq_off.head         ) as *const atomic::AtomicU32;
@@ -41,7 +69,7 @@ impl Inner {
         let ring_mask    = cq_mmap.offset(p.cq_off.ring_mask    ).cast::<u32>().read();
         let ring_entries = cq_mmap.offset(p.cq_off.ring_entries ).cast::<u32>().read();
         let overflow     = cq_mmap.offset(p.cq_off.overflow     ) as *const atomic::AtomicU32;
-        let cqes         = cq_mmap.offset(p.cq_off.cqes         ) as *const sys::io_uring_cqe;
+        let cqes         = cq_mmap.offset(p.cq_off.cqes         ) as *const E;
         let flags        = cq_mmap.offset(p.cq_off.flags        ) as *const atomic::AtomicU32;
 
         Self {
@@ -56,7 +84,7 @@ impl Inner {
     }
 
     #[inline]
-    pub(crate) unsafe fn borrow_shared(&self) -> CompletionQueue<'_> {
+    pub(crate) unsafe fn borrow_shared(&self) -> CompletionQueue<'_, E> {
         CompletionQueue {
             head: unsync_load(self.head),
             tail: (*self.tail).load(atomic::Ordering::Acquire),
@@ -65,12 +93,12 @@ impl Inner {
     }
 
     #[inline]
-    pub(crate) fn borrow(&mut self) -> CompletionQueue<'_> {
+    pub(crate) fn borrow(&mut self) -> CompletionQueue<'_, E> {
         unsafe { self.borrow_shared() }
     }
 }
 
-impl CompletionQueue<'_> {
+impl<E: EntryMarker> CompletionQueue<'_, E> {
     /// Synchronize this type with the real completion queue.
     ///
     /// This will flush any entries consumed in this iterator and will make available new entries
@@ -124,48 +152,41 @@ impl CompletionQueue<'_> {
 
     #[cfg(feature = "unstable")]
     #[inline]
-    pub fn fill<'a>(&mut self, entries: &'a mut [MaybeUninit<Entry>]) -> &'a mut [Entry] {
+    pub fn fill<'a>(&mut self, entries: &'a mut [MaybeUninit<E>]) -> &'a mut [E] {
         let len = std::cmp::min(self.len(), entries.len());
 
         for entry in &mut entries[..len] {
-            *entry = MaybeUninit::new(Entry(unsafe {
-                mem::transmute_copy(
-                    &*self
-                        .queue
-                        .cqes
-                        .add((self.head & self.queue.ring_mask) as usize),
-                )
-            }));
-            self.head = self.head.wrapping_add(1);
+            entry.write(unsafe { self.pop() });
         }
 
-        unsafe { std::slice::from_raw_parts_mut(entries as *mut _ as *mut Entry, len) }
+        unsafe { std::slice::from_raw_parts_mut(entries as *mut _ as *mut E, len) }
+    }
+
+    #[inline]
+    unsafe fn pop(&mut self) -> E {
+        let entry = &*self
+            .queue
+            .cqes
+            .add((self.head & self.queue.ring_mask) as usize);
+        self.head = self.head.wrapping_add(1);
+        entry.clone()
     }
 }
 
-impl Drop for CompletionQueue<'_> {
+impl<E: EntryMarker> Drop for CompletionQueue<'_, E> {
     #[inline]
     fn drop(&mut self) {
         unsafe { &*self.queue.head }.store(self.head, atomic::Ordering::Release);
     }
 }
 
-impl Iterator for CompletionQueue<'_> {
-    type Item = Entry;
+impl<E: EntryMarker> Iterator for CompletionQueue<'_, E> {
+    type Item = E;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.head != self.tail {
-            let entry = unsafe {
-                mem::transmute_copy(
-                    &*self
-                        .queue
-                        .cqes
-                        .add((self.head & self.queue.ring_mask) as usize),
-                )
-            };
-            self.head = self.head.wrapping_add(1);
-            Some(Entry(entry))
+            Some(unsafe { self.pop() })
         } else {
             None
         }
@@ -177,7 +198,7 @@ impl Iterator for CompletionQueue<'_> {
     }
 }
 
-impl ExactSizeIterator for CompletionQueue<'_> {
+impl<E: EntryMarker> ExactSizeIterator for CompletionQueue<'_, E> {
     #[inline]
     fn len(&self) -> usize {
         self.tail.wrapping_sub(self.head) as usize
@@ -210,6 +231,12 @@ impl Entry {
     }
 }
 
+impl Sealed for Entry {
+    const ADDITIONAL_FLAGS: u32 = 0;
+}
+
+impl EntryMarker for Entry {}
+
 impl Clone for Entry {
     fn clone(&self) -> Entry {
         // io_uring_cqe doesn't implement Clone due to the 'big_cqe' incomplete array field.
@@ -217,12 +244,72 @@ impl Clone for Entry {
     }
 }
 
-impl fmt::Debug for Entry {
+impl Debug for Entry {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Entry")
-            .field("result", &self.0.res)
-            .field("user_data", &self.0.user_data)
-            .field("flags", &self.0.flags)
+            .field("result", &self.result())
+            .field("user_data", &self.user_data())
+            .field("flags", &self.flags())
+            .finish()
+    }
+}
+
+#[cfg(feature = "unstable")]
+impl Entry32 {
+    /// The operation-specific result code. For example, for a [`Read`](crate::opcode::Read)
+    /// operation this is equivalent to the return value of the `read(2)` system call.
+    #[inline]
+    pub fn result(&self) -> i32 {
+        self.0 .0.res
+    }
+
+    /// The user data of the request, as set by
+    /// [`Entry::user_data`](crate::squeue::Entry::user_data) on the submission queue event.
+    #[inline]
+    pub fn user_data(&self) -> u64 {
+        self.0 .0.user_data
+    }
+
+    /// Metadata related to the operation.
+    ///
+    /// This is currently used for:
+    /// - Storing the selected buffer ID, if one was selected. See
+    /// [`BUFFER_SELECT`](crate::squeue::Flags::BUFFER_SELECT) for more info.
+    #[inline]
+    pub fn flags(&self) -> u32 {
+        self.0 .0.flags
+    }
+
+    /// Additional data available in 32-byte completion queue entries (CQEs).
+    #[inline]
+    pub fn big_cqe(&self) -> &[u64; 2] {
+        &self.1
+    }
+}
+
+#[cfg(feature = "unstable")]
+impl Sealed for Entry32 {
+    const ADDITIONAL_FLAGS: u32 = sys::IORING_SETUP_CQE32;
+}
+
+#[cfg(feature = "unstable")]
+impl EntryMarker for Entry32 {}
+
+#[cfg(feature = "unstable")]
+impl From<Entry32> for Entry {
+    fn from(entry32: Entry32) -> Self {
+        entry32.0
+    }
+}
+
+#[cfg(feature = "unstable")]
+impl Debug for Entry32 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Entry32")
+            .field("result", &self.result())
+            .field("user_data", &self.user_data())
+            .field("flags", &self.flags())
+            .field("big_cqe", &self.big_cqe())
             .finish()
     }
 }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -53,7 +53,7 @@ macro_rules! opcode {
         pub const CODE = $opcode:expr;
 
         $( #[$build_meta:meta] )*
-        pub fn build($self:ident) -> Entry $build_block:block
+        pub fn build($self:ident) -> $entry:ty $build_block:block
     ) => {
         $( #[$outer] )*
         pub struct $name {
@@ -87,7 +87,7 @@ macro_rules! opcode {
 
             $( #[$build_meta] )*
             #[inline]
-            pub fn build($self) -> Entry $build_block
+            pub fn build($self) -> $entry $build_block
         }
     }
 }

--- a/src/squeue.rs
+++ b/src/squeue.rs
@@ -10,7 +10,7 @@ use crate::util::{unsync_load, Mmap};
 
 use bitflags::bitflags;
 
-pub(crate) struct Inner {
+pub(crate) struct Inner<E: EntryMarker> {
     pub(crate) head: *const atomic::AtomicU32,
     pub(crate) tail: *const atomic::AtomicU32,
     pub(crate) ring_mask: u32,
@@ -18,21 +18,50 @@ pub(crate) struct Inner {
     pub(crate) flags: *const atomic::AtomicU32,
     dropped: *const atomic::AtomicU32,
 
-    pub(crate) sqes: *mut sys::io_uring_sqe,
+    pub(crate) sqes: *mut E,
 }
 
 /// An io_uring instance's submission queue. This is used to send I/O requests to the kernel.
-pub struct SubmissionQueue<'a> {
+pub struct SubmissionQueue<'a, E: EntryMarker = Entry> {
     head: u32,
     tail: u32,
-    queue: &'a Inner,
+    queue: &'a Inner<E>,
 }
 
-/// An entry in the submission queue, representing a request for an I/O operation.
+pub(crate) use private::Sealed;
+mod private {
+    /// Private trait that we use as a supertrait of `EntryMarker` to prevent it from being
+    /// implemented from outside this crate: https://jack.wrenn.fyi/blog/private-trait-methods/
+    pub trait Sealed {
+        const ADDITIONAL_FLAGS: u32;
+    }
+}
+
+/// A submission queue entry (SQE), representing a request for an I/O operation.
 ///
-/// These can be created via the opcodes in [`opcode`](crate::opcode).
-#[repr(transparent)]
+/// This is implemented for [`Entry`] and [`Entry128`].
+pub trait EntryMarker: Clone + Debug + From<Entry> + Sealed {}
+
+/// A 64-byte submission queue entry (SQE), representing a request for an I/O operation.
+///
+/// These can be created via opcodes in [`opcode`](crate::opcode).
+#[repr(C)]
 pub struct Entry(pub(crate) sys::io_uring_sqe);
+
+/// A 128-byte submission queue entry (SQE), representing a request for an I/O operation.
+///
+/// These can be created via opcodes in [`opcode`](crate::opcode).
+#[cfg(feature = "unstable")]
+#[repr(C)]
+#[derive(Clone)]
+pub struct Entry128(pub(crate) Entry, pub(crate) [u8; 64]);
+
+#[test]
+fn test_entry_sizes() {
+    assert_eq!(mem::size_of::<Entry>(), 64);
+    #[cfg(feature = "unstable")]
+    assert_eq!(mem::size_of::<Entry128>(), 128);
+}
 
 bitflags! {
     /// Submission flags
@@ -94,7 +123,7 @@ bitflags! {
     }
 }
 
-impl Inner {
+impl<E: EntryMarker> Inner<E> {
     #[rustfmt::skip]
     pub(crate) unsafe fn new(
         sq_mmap: &Mmap,
@@ -109,7 +138,7 @@ impl Inner {
         let dropped      = sq_mmap.offset(p.sq_off.dropped     ) as *const atomic::AtomicU32;
         let array        = sq_mmap.offset(p.sq_off.array       ) as *mut u32;
 
-        let sqes         = sqe_mmap.as_mut_ptr() as *mut sys::io_uring_sqe;
+        let sqes         = sqe_mmap.as_mut_ptr() as *mut E;
 
         // To keep it simple, map it directly to `sqes`.
         for i in 0..ring_entries {
@@ -128,7 +157,7 @@ impl Inner {
     }
 
     #[inline]
-    pub(crate) unsafe fn borrow_shared(&self) -> SubmissionQueue<'_> {
+    pub(crate) unsafe fn borrow_shared(&self) -> SubmissionQueue<'_, E> {
         SubmissionQueue {
             head: (*self.head).load(atomic::Ordering::Acquire),
             tail: unsync_load(self.tail),
@@ -137,12 +166,12 @@ impl Inner {
     }
 
     #[inline]
-    pub(crate) fn borrow(&mut self) -> SubmissionQueue<'_> {
+    pub(crate) fn borrow(&mut self) -> SubmissionQueue<'_, E> {
         unsafe { self.borrow_shared() }
     }
 }
 
-impl SubmissionQueue<'_> {
+impl<E: EntryMarker> SubmissionQueue<'_, E> {
     /// Synchronize this type with the real submission queue.
     ///
     /// This will flush any entries added by [`push`](Self::push) or
@@ -203,28 +232,24 @@ impl SubmissionQueue<'_> {
         self.len() == self.capacity()
     }
 
-    /// Attempts to push an [`Entry`] into the queue.
+    /// Attempts to push an entry into the queue.
     /// If the queue is full, an error is returned.
     ///
     /// # Safety
     ///
-    /// Developers must ensure that parameters of the [`Entry`] (such as buffer) are valid and will
+    /// Developers must ensure that parameters of the entry (such as buffer) are valid and will
     /// be valid for the entire duration of the operation, otherwise it may cause memory problems.
     #[inline]
-    pub unsafe fn push(&mut self, Entry(entry): &Entry) -> Result<(), PushError> {
+    pub unsafe fn push(&mut self, entry: &E) -> Result<(), PushError> {
         if !self.is_full() {
-            *self
-                .queue
-                .sqes
-                .add((self.tail & self.queue.ring_mask) as usize) = mem::transmute_copy(entry);
-            self.tail = self.tail.wrapping_add(1);
+            self.push_unchecked(entry);
             Ok(())
         } else {
             Err(PushError)
         }
     }
 
-    /// Attempts to push several [entries](Entry) into the queue.
+    /// Attempts to push several entries into the queue.
     /// If the queue does not have space for all of the entries, an error is returned.
     ///
     /// # Safety
@@ -234,24 +259,29 @@ impl SubmissionQueue<'_> {
     /// problems.
     #[cfg(feature = "unstable")]
     #[inline]
-    pub unsafe fn push_multiple(&mut self, entries: &[Entry]) -> Result<(), PushError> {
+    pub unsafe fn push_multiple(&mut self, entries: &[E]) -> Result<(), PushError> {
         if self.capacity() - self.len() < entries.len() {
             return Err(PushError);
         }
 
-        for Entry(entry) in entries {
-            *self
-                .queue
-                .sqes
-                .add((self.tail & self.queue.ring_mask) as usize) = mem::transmute_copy(entry);
-            self.tail = self.tail.wrapping_add(1);
+        for entry in entries {
+            self.push_unchecked(entry);
         }
 
         Ok(())
     }
+
+    #[inline]
+    unsafe fn push_unchecked(&mut self, entry: &E) {
+        *self
+            .queue
+            .sqes
+            .add((self.tail & self.queue.ring_mask) as usize) = entry.clone();
+        self.tail = self.tail.wrapping_add(1);
+    }
 }
 
-impl Drop for SubmissionQueue<'_> {
+impl<E: EntryMarker> Drop for SubmissionQueue<'_, E> {
     #[inline]
     fn drop(&mut self) {
         unsafe { &*self.queue.tail }.store(self.tail, atomic::Ordering::Release);
@@ -285,10 +315,80 @@ impl Entry {
     }
 }
 
+impl Sealed for Entry {
+    const ADDITIONAL_FLAGS: u32 = 0;
+}
+
+impl EntryMarker for Entry {}
+
 impl Clone for Entry {
     fn clone(&self) -> Entry {
         // io_uring_sqe doesn't implement Clone due to the 'cmd' incomplete array field.
         Entry(unsafe { mem::transmute_copy(&self.0) })
+    }
+}
+
+impl Debug for Entry {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Entry")
+            .field("op_code", &self.0.opcode)
+            .field("flags", &self.0.flags)
+            .field("user_data", &self.0.user_data)
+            .finish()
+    }
+}
+
+#[cfg(feature = "unstable")]
+impl Entry128 {
+    /// Set the submission event's [flags](Flags).
+    #[inline]
+    pub fn flags(mut self, flags: Flags) -> Entry128 {
+        self.0 .0.flags |= flags.bits();
+        self
+    }
+
+    /// Set the user data. This is an application-supplied value that will be passed straight
+    /// through into the [completion queue entry](crate::cqueue::Entry::user_data).
+    #[inline]
+    pub fn user_data(mut self, user_data: u64) -> Entry128 {
+        self.0 .0.user_data = user_data;
+        self
+    }
+
+    /// Set the personality of this event. You can obtain a personality using
+    /// [`Submitter::register_personality`](crate::Submitter::register_personality).
+    ///
+    /// Requires the `unstable` feature.
+    #[cfg(feature = "unstable")]
+    pub fn personality(mut self, personality: u16) -> Entry128 {
+        self.0 .0.personality = personality;
+        self
+    }
+}
+
+#[cfg(feature = "unstable")]
+impl Sealed for Entry128 {
+    const ADDITIONAL_FLAGS: u32 = sys::IORING_SETUP_SQE128;
+}
+
+#[cfg(feature = "unstable")]
+impl EntryMarker for Entry128 {}
+
+#[cfg(feature = "unstable")]
+impl From<Entry> for Entry128 {
+    fn from(entry: Entry) -> Entry128 {
+        Entry128(entry, [0u8; 64])
+    }
+}
+
+#[cfg(feature = "unstable")]
+impl Debug for Entry128 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Entry128")
+            .field("op_code", &self.0 .0.opcode)
+            .field("flags", &self.0 .0.flags)
+            .field("user_data", &self.0 .0.user_data)
+            .finish()
     }
 }
 
@@ -305,24 +405,12 @@ impl Display for PushError {
 
 impl Error for PushError {}
 
-impl Debug for Entry {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Entry")
-            .field("op_code", &self.0.opcode)
-            .field("flags", &self.0.flags)
-            .field("user_data", &self.0.user_data)
-            .finish()
-    }
-}
-
-impl Debug for SubmissionQueue<'_> {
+impl<E: EntryMarker> Debug for SubmissionQueue<'_, E> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_list();
         let mut pos = self.head;
         while pos != self.tail {
-            let entry: &Entry = unsafe {
-                &*(self.queue.sqes.add((pos & self.queue.ring_mask) as usize) as *const Entry)
-            };
+            let entry: &E = unsafe { &*self.queue.sqes.add((pos & self.queue.ring_mask) as usize) };
             d.entry(&entry);
             pos = pos.wrapping_add(1);
         }

--- a/src/sys/sys.rs
+++ b/src/sys/sys.rs
@@ -30,9 +30,53 @@ impl<T> ::core::fmt::Debug for __IncompleteArrayField<T> {
         fmt.write_str("__IncompleteArrayField")
     }
 }
+#[repr(C)]
+pub struct __BindgenUnionField<T>(::core::marker::PhantomData<T>);
+impl<T> __BindgenUnionField<T> {
+    #[inline]
+    pub const fn new() -> Self {
+        __BindgenUnionField(::core::marker::PhantomData)
+    }
+    #[inline]
+    pub unsafe fn as_ref(&self) -> &T {
+        ::core::mem::transmute(self)
+    }
+    #[inline]
+    pub unsafe fn as_mut(&mut self) -> &mut T {
+        ::core::mem::transmute(self)
+    }
+}
+impl<T> ::core::default::Default for __BindgenUnionField<T> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self::new()
+    }
+}
+impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}
+impl<T> ::core::fmt::Debug for __BindgenUnionField<T> {
+    fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        fmt.write_str("__BindgenUnionField")
+    }
+}
+impl<T> ::core::hash::Hash for __BindgenUnionField<T> {
+    fn hash<H: ::core::hash::Hasher>(&self, _state: &mut H) {}
+}
+impl<T> ::core::cmp::PartialEq for __BindgenUnionField<T> {
+    fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
+        true
+    }
+}
+impl<T> ::core::cmp::Eq for __BindgenUnionField<T> {}
 pub const __NR_io_uring_setup: u32 = 425;
 pub const __NR_io_uring_enter: u32 = 426;
 pub const __NR_io_uring_register: u32 = 427;
+pub const IORING_FILE_INDEX_ALLOC: i32 = -1;
 pub const IORING_SETUP_IOPOLL: u32 = 1;
 pub const IORING_SETUP_SQPOLL: u32 = 2;
 pub const IORING_SETUP_SQ_AFF: u32 = 4;
@@ -40,6 +84,11 @@ pub const IORING_SETUP_CQSIZE: u32 = 8;
 pub const IORING_SETUP_CLAMP: u32 = 16;
 pub const IORING_SETUP_ATTACH_WQ: u32 = 32;
 pub const IORING_SETUP_R_DISABLED: u32 = 64;
+pub const IORING_SETUP_SUBMIT_ALL: u32 = 128;
+pub const IORING_SETUP_COOP_TASKRUN: u32 = 256;
+pub const IORING_SETUP_TASKRUN_FLAG: u32 = 512;
+pub const IORING_SETUP_SQE128: u32 = 1024;
+pub const IORING_SETUP_CQE32: u32 = 2048;
 pub const IORING_FSYNC_DATASYNC: u32 = 1;
 pub const IORING_TIMEOUT_ABS: u32 = 1;
 pub const IORING_TIMEOUT_UPDATE: u32 = 2;
@@ -53,18 +102,26 @@ pub const SPLICE_F_FD_IN_FIXED: u32 = 2147483648;
 pub const IORING_POLL_ADD_MULTI: u32 = 1;
 pub const IORING_POLL_UPDATE_EVENTS: u32 = 2;
 pub const IORING_POLL_UPDATE_USER_DATA: u32 = 4;
+pub const IORING_ASYNC_CANCEL_ALL: u32 = 1;
+pub const IORING_ASYNC_CANCEL_FD: u32 = 2;
+pub const IORING_ASYNC_CANCEL_ANY: u32 = 4;
+pub const IORING_RECVSEND_POLL_FIRST: u32 = 1;
+pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
+pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
 pub const IORING_OFF_SQ_RING: u32 = 0;
 pub const IORING_OFF_CQ_RING: u32 = 134217728;
 pub const IORING_OFF_SQES: u32 = 268435456;
 pub const IORING_SQ_NEED_WAKEUP: u32 = 1;
 pub const IORING_SQ_CQ_OVERFLOW: u32 = 2;
+pub const IORING_SQ_TASKRUN: u32 = 4;
 pub const IORING_CQ_EVENTFD_DISABLED: u32 = 1;
 pub const IORING_ENTER_GETEVENTS: u32 = 1;
 pub const IORING_ENTER_SQ_WAKEUP: u32 = 2;
 pub const IORING_ENTER_SQ_WAIT: u32 = 4;
 pub const IORING_ENTER_EXT_ARG: u32 = 8;
+pub const IORING_ENTER_REGISTERED_RING: u32 = 16;
 pub const IORING_FEAT_SINGLE_MMAP: u32 = 1;
 pub const IORING_FEAT_NODROP: u32 = 2;
 pub const IORING_FEAT_SUBMIT_STABLE: u32 = 4;
@@ -78,6 +135,7 @@ pub const IORING_FEAT_NATIVE_WORKERS: u32 = 512;
 pub const IORING_FEAT_RSRC_TAGS: u32 = 1024;
 pub const IORING_FEAT_CQE_SKIP: u32 = 2048;
 pub const IORING_FEAT_LINKED_FILE: u32 = 4096;
+pub const IORING_RSRC_REGISTER_SPARSE: u32 = 1;
 pub const IORING_REGISTER_FILES_SKIP: i32 = -2;
 pub const IO_URING_OP_SUPPORTED: u32 = 1;
 pub type __u8 = libc::c_uchar;
@@ -212,7 +270,6 @@ fn bindgen_test_layout_open_how() {
 }
 pub type __kernel_rwf_t = libc::c_int;
 #[repr(C)]
-#[derive(Copy, Clone)]
 pub struct io_uring_sqe {
     pub opcode: __u8,
     pub flags: __u8,
@@ -226,13 +283,75 @@ pub struct io_uring_sqe {
     pub __bindgen_anon_4: io_uring_sqe__bindgen_ty_4,
     pub personality: __u16,
     pub __bindgen_anon_5: io_uring_sqe__bindgen_ty_5,
-    pub __pad2: [__u64; 2usize],
+    pub __bindgen_anon_6: io_uring_sqe__bindgen_ty_6,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union io_uring_sqe__bindgen_ty_1 {
     pub off: __u64,
     pub addr2: __u64,
+    pub __bindgen_anon_1: io_uring_sqe__bindgen_ty_1__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct io_uring_sqe__bindgen_ty_1__bindgen_ty_1 {
+    pub cmd_op: __u32,
+    pub __pad1: __u32,
+}
+#[test]
+fn bindgen_test_layout_io_uring_sqe__bindgen_ty_1__bindgen_ty_1() {
+    assert_eq!(
+        ::core::mem::size_of::<io_uring_sqe__bindgen_ty_1__bindgen_ty_1>(),
+        8usize,
+        concat!(
+            "Size of: ",
+            stringify!(io_uring_sqe__bindgen_ty_1__bindgen_ty_1)
+        )
+    );
+    assert_eq!(
+        ::core::mem::align_of::<io_uring_sqe__bindgen_ty_1__bindgen_ty_1>(),
+        4usize,
+        concat!(
+            "Alignment of ",
+            stringify!(io_uring_sqe__bindgen_ty_1__bindgen_ty_1)
+        )
+    );
+    fn test_field_cmd_op() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::core::mem::MaybeUninit::<io_uring_sqe__bindgen_ty_1__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).cmd_op) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(io_uring_sqe__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(cmd_op)
+            )
+        );
+    }
+    test_field_cmd_op();
+    fn test_field___pad1() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::core::mem::MaybeUninit::<io_uring_sqe__bindgen_ty_1__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).__pad1) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(io_uring_sqe__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(__pad1)
+            )
+        );
+    }
+    test_field___pad1();
 }
 #[test]
 fn bindgen_test_layout_io_uring_sqe__bindgen_ty_1() {
@@ -371,6 +490,7 @@ pub union io_uring_sqe__bindgen_ty_3 {
     pub rename_flags: __u32,
     pub unlink_flags: __u32,
     pub hardlink_flags: __u32,
+    pub xattr_flags: __u32,
 }
 #[test]
 fn bindgen_test_layout_io_uring_sqe__bindgen_ty_3() {
@@ -656,6 +776,23 @@ fn bindgen_test_layout_io_uring_sqe__bindgen_ty_3() {
         );
     }
     test_field_hardlink_flags();
+    fn test_field_xattr_flags() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<io_uring_sqe__bindgen_ty_3>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).xattr_flags) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(io_uring_sqe__bindgen_ty_3),
+                "::",
+                stringify!(xattr_flags)
+            )
+        );
+    }
+    test_field_xattr_flags();
 }
 impl Default for io_uring_sqe__bindgen_ty_3 {
     fn default() -> Self {
@@ -782,6 +919,112 @@ fn bindgen_test_layout_io_uring_sqe__bindgen_ty_5() {
     test_field_file_index();
 }
 impl Default for io_uring_sqe__bindgen_ty_5 {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+pub struct io_uring_sqe__bindgen_ty_6 {
+    pub __bindgen_anon_1: __BindgenUnionField<io_uring_sqe__bindgen_ty_6__bindgen_ty_1>,
+    pub cmd: __BindgenUnionField<[__u8; 0usize]>,
+    pub bindgen_union_field: [u64; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct io_uring_sqe__bindgen_ty_6__bindgen_ty_1 {
+    pub addr3: __u64,
+    pub __pad2: [__u64; 1usize],
+}
+#[test]
+fn bindgen_test_layout_io_uring_sqe__bindgen_ty_6__bindgen_ty_1() {
+    assert_eq!(
+        ::core::mem::size_of::<io_uring_sqe__bindgen_ty_6__bindgen_ty_1>(),
+        16usize,
+        concat!(
+            "Size of: ",
+            stringify!(io_uring_sqe__bindgen_ty_6__bindgen_ty_1)
+        )
+    );
+    assert_eq!(
+        ::core::mem::align_of::<io_uring_sqe__bindgen_ty_6__bindgen_ty_1>(),
+        8usize,
+        concat!(
+            "Alignment of ",
+            stringify!(io_uring_sqe__bindgen_ty_6__bindgen_ty_1)
+        )
+    );
+    fn test_field_addr3() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::core::mem::MaybeUninit::<io_uring_sqe__bindgen_ty_6__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).addr3) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(io_uring_sqe__bindgen_ty_6__bindgen_ty_1),
+                "::",
+                stringify!(addr3)
+            )
+        );
+    }
+    test_field_addr3();
+    fn test_field___pad2() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::core::mem::MaybeUninit::<io_uring_sqe__bindgen_ty_6__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).__pad2) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(io_uring_sqe__bindgen_ty_6__bindgen_ty_1),
+                "::",
+                stringify!(__pad2)
+            )
+        );
+    }
+    test_field___pad2();
+}
+#[test]
+fn bindgen_test_layout_io_uring_sqe__bindgen_ty_6() {
+    assert_eq!(
+        ::core::mem::size_of::<io_uring_sqe__bindgen_ty_6>(),
+        16usize,
+        concat!("Size of: ", stringify!(io_uring_sqe__bindgen_ty_6))
+    );
+    assert_eq!(
+        ::core::mem::align_of::<io_uring_sqe__bindgen_ty_6>(),
+        8usize,
+        concat!("Alignment of ", stringify!(io_uring_sqe__bindgen_ty_6))
+    );
+    fn test_field_cmd() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<io_uring_sqe__bindgen_ty_6>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).cmd) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(io_uring_sqe__bindgen_ty_6),
+                "::",
+                stringify!(cmd)
+            )
+        );
+    }
+    test_field_cmd();
+}
+impl Default for io_uring_sqe__bindgen_ty_6 {
     fn default() -> Self {
         let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -921,23 +1164,6 @@ fn bindgen_test_layout_io_uring_sqe() {
         );
     }
     test_field_personality();
-    fn test_field___pad2() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::core::mem::MaybeUninit::<io_uring_sqe>::uninit();
-                let ptr = uninit.as_ptr();
-                ::core::ptr::addr_of!((*ptr).__pad2) as usize - ptr as usize
-            },
-            48usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(io_uring_sqe),
-                "::",
-                stringify!(__pad2)
-            )
-        );
-    }
-    test_field___pad2();
 }
 impl Default for io_uring_sqe {
     fn default() -> Self {
@@ -956,54 +1182,62 @@ pub const IOSQE_ASYNC_BIT: _bindgen_ty_4 = 4;
 pub const IOSQE_BUFFER_SELECT_BIT: _bindgen_ty_4 = 5;
 pub const IOSQE_CQE_SKIP_SUCCESS_BIT: _bindgen_ty_4 = 6;
 pub type _bindgen_ty_4 = libc::c_uint;
-pub const IORING_OP_NOP: _bindgen_ty_5 = 0;
-pub const IORING_OP_READV: _bindgen_ty_5 = 1;
-pub const IORING_OP_WRITEV: _bindgen_ty_5 = 2;
-pub const IORING_OP_FSYNC: _bindgen_ty_5 = 3;
-pub const IORING_OP_READ_FIXED: _bindgen_ty_5 = 4;
-pub const IORING_OP_WRITE_FIXED: _bindgen_ty_5 = 5;
-pub const IORING_OP_POLL_ADD: _bindgen_ty_5 = 6;
-pub const IORING_OP_POLL_REMOVE: _bindgen_ty_5 = 7;
-pub const IORING_OP_SYNC_FILE_RANGE: _bindgen_ty_5 = 8;
-pub const IORING_OP_SENDMSG: _bindgen_ty_5 = 9;
-pub const IORING_OP_RECVMSG: _bindgen_ty_5 = 10;
-pub const IORING_OP_TIMEOUT: _bindgen_ty_5 = 11;
-pub const IORING_OP_TIMEOUT_REMOVE: _bindgen_ty_5 = 12;
-pub const IORING_OP_ACCEPT: _bindgen_ty_5 = 13;
-pub const IORING_OP_ASYNC_CANCEL: _bindgen_ty_5 = 14;
-pub const IORING_OP_LINK_TIMEOUT: _bindgen_ty_5 = 15;
-pub const IORING_OP_CONNECT: _bindgen_ty_5 = 16;
-pub const IORING_OP_FALLOCATE: _bindgen_ty_5 = 17;
-pub const IORING_OP_OPENAT: _bindgen_ty_5 = 18;
-pub const IORING_OP_CLOSE: _bindgen_ty_5 = 19;
-pub const IORING_OP_FILES_UPDATE: _bindgen_ty_5 = 20;
-pub const IORING_OP_STATX: _bindgen_ty_5 = 21;
-pub const IORING_OP_READ: _bindgen_ty_5 = 22;
-pub const IORING_OP_WRITE: _bindgen_ty_5 = 23;
-pub const IORING_OP_FADVISE: _bindgen_ty_5 = 24;
-pub const IORING_OP_MADVISE: _bindgen_ty_5 = 25;
-pub const IORING_OP_SEND: _bindgen_ty_5 = 26;
-pub const IORING_OP_RECV: _bindgen_ty_5 = 27;
-pub const IORING_OP_OPENAT2: _bindgen_ty_5 = 28;
-pub const IORING_OP_EPOLL_CTL: _bindgen_ty_5 = 29;
-pub const IORING_OP_SPLICE: _bindgen_ty_5 = 30;
-pub const IORING_OP_PROVIDE_BUFFERS: _bindgen_ty_5 = 31;
-pub const IORING_OP_REMOVE_BUFFERS: _bindgen_ty_5 = 32;
-pub const IORING_OP_TEE: _bindgen_ty_5 = 33;
-pub const IORING_OP_SHUTDOWN: _bindgen_ty_5 = 34;
-pub const IORING_OP_RENAMEAT: _bindgen_ty_5 = 35;
-pub const IORING_OP_UNLINKAT: _bindgen_ty_5 = 36;
-pub const IORING_OP_MKDIRAT: _bindgen_ty_5 = 37;
-pub const IORING_OP_SYMLINKAT: _bindgen_ty_5 = 38;
-pub const IORING_OP_LINKAT: _bindgen_ty_5 = 39;
-pub const IORING_OP_LAST: _bindgen_ty_5 = 40;
-pub type _bindgen_ty_5 = libc::c_uint;
+pub const IORING_OP_NOP: io_uring_op = 0;
+pub const IORING_OP_READV: io_uring_op = 1;
+pub const IORING_OP_WRITEV: io_uring_op = 2;
+pub const IORING_OP_FSYNC: io_uring_op = 3;
+pub const IORING_OP_READ_FIXED: io_uring_op = 4;
+pub const IORING_OP_WRITE_FIXED: io_uring_op = 5;
+pub const IORING_OP_POLL_ADD: io_uring_op = 6;
+pub const IORING_OP_POLL_REMOVE: io_uring_op = 7;
+pub const IORING_OP_SYNC_FILE_RANGE: io_uring_op = 8;
+pub const IORING_OP_SENDMSG: io_uring_op = 9;
+pub const IORING_OP_RECVMSG: io_uring_op = 10;
+pub const IORING_OP_TIMEOUT: io_uring_op = 11;
+pub const IORING_OP_TIMEOUT_REMOVE: io_uring_op = 12;
+pub const IORING_OP_ACCEPT: io_uring_op = 13;
+pub const IORING_OP_ASYNC_CANCEL: io_uring_op = 14;
+pub const IORING_OP_LINK_TIMEOUT: io_uring_op = 15;
+pub const IORING_OP_CONNECT: io_uring_op = 16;
+pub const IORING_OP_FALLOCATE: io_uring_op = 17;
+pub const IORING_OP_OPENAT: io_uring_op = 18;
+pub const IORING_OP_CLOSE: io_uring_op = 19;
+pub const IORING_OP_FILES_UPDATE: io_uring_op = 20;
+pub const IORING_OP_STATX: io_uring_op = 21;
+pub const IORING_OP_READ: io_uring_op = 22;
+pub const IORING_OP_WRITE: io_uring_op = 23;
+pub const IORING_OP_FADVISE: io_uring_op = 24;
+pub const IORING_OP_MADVISE: io_uring_op = 25;
+pub const IORING_OP_SEND: io_uring_op = 26;
+pub const IORING_OP_RECV: io_uring_op = 27;
+pub const IORING_OP_OPENAT2: io_uring_op = 28;
+pub const IORING_OP_EPOLL_CTL: io_uring_op = 29;
+pub const IORING_OP_SPLICE: io_uring_op = 30;
+pub const IORING_OP_PROVIDE_BUFFERS: io_uring_op = 31;
+pub const IORING_OP_REMOVE_BUFFERS: io_uring_op = 32;
+pub const IORING_OP_TEE: io_uring_op = 33;
+pub const IORING_OP_SHUTDOWN: io_uring_op = 34;
+pub const IORING_OP_RENAMEAT: io_uring_op = 35;
+pub const IORING_OP_UNLINKAT: io_uring_op = 36;
+pub const IORING_OP_MKDIRAT: io_uring_op = 37;
+pub const IORING_OP_SYMLINKAT: io_uring_op = 38;
+pub const IORING_OP_LINKAT: io_uring_op = 39;
+pub const IORING_OP_MSG_RING: io_uring_op = 40;
+pub const IORING_OP_FSETXATTR: io_uring_op = 41;
+pub const IORING_OP_SETXATTR: io_uring_op = 42;
+pub const IORING_OP_FGETXATTR: io_uring_op = 43;
+pub const IORING_OP_GETXATTR: io_uring_op = 44;
+pub const IORING_OP_SOCKET: io_uring_op = 45;
+pub const IORING_OP_URING_CMD: io_uring_op = 46;
+pub const IORING_OP_LAST: io_uring_op = 47;
+pub type io_uring_op = libc::c_uint;
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Default)]
 pub struct io_uring_cqe {
     pub user_data: __u64,
     pub res: __s32,
     pub flags: __u32,
+    pub big_cqe: __IncompleteArrayField<__u64>,
 }
 #[test]
 fn bindgen_test_layout_io_uring_cqe() {
@@ -1068,9 +1302,26 @@ fn bindgen_test_layout_io_uring_cqe() {
         );
     }
     test_field_flags();
+    fn test_field_big_cqe() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<io_uring_cqe>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).big_cqe) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(io_uring_cqe),
+                "::",
+                stringify!(big_cqe)
+            )
+        );
+    }
+    test_field_big_cqe();
 }
-pub const IORING_CQE_BUFFER_SHIFT: _bindgen_ty_6 = 16;
-pub type _bindgen_ty_6 = libc::c_uint;
+pub const IORING_CQE_BUFFER_SHIFT: _bindgen_ty_5 = 16;
+pub type _bindgen_ty_5 = libc::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct io_sqring_offsets {
@@ -1626,28 +1877,32 @@ fn bindgen_test_layout_io_uring_params() {
     }
     test_field_cq_off();
 }
-pub const IORING_REGISTER_BUFFERS: _bindgen_ty_7 = 0;
-pub const IORING_UNREGISTER_BUFFERS: _bindgen_ty_7 = 1;
-pub const IORING_REGISTER_FILES: _bindgen_ty_7 = 2;
-pub const IORING_UNREGISTER_FILES: _bindgen_ty_7 = 3;
-pub const IORING_REGISTER_EVENTFD: _bindgen_ty_7 = 4;
-pub const IORING_UNREGISTER_EVENTFD: _bindgen_ty_7 = 5;
-pub const IORING_REGISTER_FILES_UPDATE: _bindgen_ty_7 = 6;
-pub const IORING_REGISTER_EVENTFD_ASYNC: _bindgen_ty_7 = 7;
-pub const IORING_REGISTER_PROBE: _bindgen_ty_7 = 8;
-pub const IORING_REGISTER_PERSONALITY: _bindgen_ty_7 = 9;
-pub const IORING_UNREGISTER_PERSONALITY: _bindgen_ty_7 = 10;
-pub const IORING_REGISTER_RESTRICTIONS: _bindgen_ty_7 = 11;
-pub const IORING_REGISTER_ENABLE_RINGS: _bindgen_ty_7 = 12;
-pub const IORING_REGISTER_FILES2: _bindgen_ty_7 = 13;
-pub const IORING_REGISTER_FILES_UPDATE2: _bindgen_ty_7 = 14;
-pub const IORING_REGISTER_BUFFERS2: _bindgen_ty_7 = 15;
-pub const IORING_REGISTER_BUFFERS_UPDATE: _bindgen_ty_7 = 16;
-pub const IORING_REGISTER_IOWQ_AFF: _bindgen_ty_7 = 17;
-pub const IORING_UNREGISTER_IOWQ_AFF: _bindgen_ty_7 = 18;
-pub const IORING_REGISTER_IOWQ_MAX_WORKERS: _bindgen_ty_7 = 19;
-pub const IORING_REGISTER_LAST: _bindgen_ty_7 = 20;
-pub type _bindgen_ty_7 = libc::c_uint;
+pub const IORING_REGISTER_BUFFERS: _bindgen_ty_6 = 0;
+pub const IORING_UNREGISTER_BUFFERS: _bindgen_ty_6 = 1;
+pub const IORING_REGISTER_FILES: _bindgen_ty_6 = 2;
+pub const IORING_UNREGISTER_FILES: _bindgen_ty_6 = 3;
+pub const IORING_REGISTER_EVENTFD: _bindgen_ty_6 = 4;
+pub const IORING_UNREGISTER_EVENTFD: _bindgen_ty_6 = 5;
+pub const IORING_REGISTER_FILES_UPDATE: _bindgen_ty_6 = 6;
+pub const IORING_REGISTER_EVENTFD_ASYNC: _bindgen_ty_6 = 7;
+pub const IORING_REGISTER_PROBE: _bindgen_ty_6 = 8;
+pub const IORING_REGISTER_PERSONALITY: _bindgen_ty_6 = 9;
+pub const IORING_UNREGISTER_PERSONALITY: _bindgen_ty_6 = 10;
+pub const IORING_REGISTER_RESTRICTIONS: _bindgen_ty_6 = 11;
+pub const IORING_REGISTER_ENABLE_RINGS: _bindgen_ty_6 = 12;
+pub const IORING_REGISTER_FILES2: _bindgen_ty_6 = 13;
+pub const IORING_REGISTER_FILES_UPDATE2: _bindgen_ty_6 = 14;
+pub const IORING_REGISTER_BUFFERS2: _bindgen_ty_6 = 15;
+pub const IORING_REGISTER_BUFFERS_UPDATE: _bindgen_ty_6 = 16;
+pub const IORING_REGISTER_IOWQ_AFF: _bindgen_ty_6 = 17;
+pub const IORING_UNREGISTER_IOWQ_AFF: _bindgen_ty_6 = 18;
+pub const IORING_REGISTER_IOWQ_MAX_WORKERS: _bindgen_ty_6 = 19;
+pub const IORING_REGISTER_RING_FDS: _bindgen_ty_6 = 20;
+pub const IORING_UNREGISTER_RING_FDS: _bindgen_ty_6 = 21;
+pub const IORING_REGISTER_PBUF_RING: _bindgen_ty_6 = 22;
+pub const IORING_UNREGISTER_PBUF_RING: _bindgen_ty_6 = 23;
+pub const IORING_REGISTER_LAST: _bindgen_ty_6 = 24;
+pub type _bindgen_ty_6 = libc::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct io_uring_files_update {
@@ -1723,7 +1978,7 @@ fn bindgen_test_layout_io_uring_files_update() {
 #[derive(Debug, Default, Copy, Clone)]
 pub struct io_uring_rsrc_register {
     pub nr: __u32,
-    pub resv: __u32,
+    pub flags: __u32,
     pub resv2: __u64,
     pub data: __u64,
     pub tags: __u64,
@@ -1757,23 +2012,23 @@ fn bindgen_test_layout_io_uring_rsrc_register() {
         );
     }
     test_field_nr();
-    fn test_field_resv() {
+    fn test_field_flags() {
         assert_eq!(
             unsafe {
                 let uninit = ::core::mem::MaybeUninit::<io_uring_rsrc_register>::uninit();
                 let ptr = uninit.as_ptr();
-                ::core::ptr::addr_of!((*ptr).resv) as usize - ptr as usize
+                ::core::ptr::addr_of!((*ptr).flags) as usize - ptr as usize
             },
             4usize,
             concat!(
                 "Offset of field: ",
                 stringify!(io_uring_rsrc_register),
                 "::",
-                stringify!(resv)
+                stringify!(flags)
             )
         );
     }
-    test_field_resv();
+    test_field_flags();
     fn test_field_resv2() {
         assert_eq!(
             unsafe {
@@ -2385,12 +2640,382 @@ impl Default for io_uring_restriction {
         }
     }
 }
-pub const IORING_RESTRICTION_REGISTER_OP: _bindgen_ty_9 = 0;
-pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_9 = 1;
-pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_9 = 2;
-pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_9 = 3;
-pub const IORING_RESTRICTION_LAST: _bindgen_ty_9 = 4;
-pub type _bindgen_ty_9 = libc::c_uint;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct io_uring_buf {
+    pub addr: __u64,
+    pub len: __u32,
+    pub bid: __u16,
+    pub resv: __u16,
+}
+#[test]
+fn bindgen_test_layout_io_uring_buf() {
+    assert_eq!(
+        ::core::mem::size_of::<io_uring_buf>(),
+        16usize,
+        concat!("Size of: ", stringify!(io_uring_buf))
+    );
+    assert_eq!(
+        ::core::mem::align_of::<io_uring_buf>(),
+        8usize,
+        concat!("Alignment of ", stringify!(io_uring_buf))
+    );
+    fn test_field_addr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<io_uring_buf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).addr) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(io_uring_buf),
+                "::",
+                stringify!(addr)
+            )
+        );
+    }
+    test_field_addr();
+    fn test_field_len() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<io_uring_buf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).len) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(io_uring_buf),
+                "::",
+                stringify!(len)
+            )
+        );
+    }
+    test_field_len();
+    fn test_field_bid() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<io_uring_buf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).bid) as usize - ptr as usize
+            },
+            12usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(io_uring_buf),
+                "::",
+                stringify!(bid)
+            )
+        );
+    }
+    test_field_bid();
+    fn test_field_resv() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<io_uring_buf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).resv) as usize - ptr as usize
+            },
+            14usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(io_uring_buf),
+                "::",
+                stringify!(resv)
+            )
+        );
+    }
+    test_field_resv();
+}
+#[repr(C)]
+pub struct io_uring_buf_ring {
+    pub __bindgen_anon_1: io_uring_buf_ring__bindgen_ty_1,
+}
+#[repr(C)]
+pub struct io_uring_buf_ring__bindgen_ty_1 {
+    pub __bindgen_anon_1: __BindgenUnionField<io_uring_buf_ring__bindgen_ty_1__bindgen_ty_1>,
+    pub bufs: __BindgenUnionField<[io_uring_buf; 0usize]>,
+    pub bindgen_union_field: [u64; 2usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct io_uring_buf_ring__bindgen_ty_1__bindgen_ty_1 {
+    pub resv1: __u64,
+    pub resv2: __u32,
+    pub resv3: __u16,
+    pub tail: __u16,
+}
+#[test]
+fn bindgen_test_layout_io_uring_buf_ring__bindgen_ty_1__bindgen_ty_1() {
+    assert_eq!(
+        ::core::mem::size_of::<io_uring_buf_ring__bindgen_ty_1__bindgen_ty_1>(),
+        16usize,
+        concat!(
+            "Size of: ",
+            stringify!(io_uring_buf_ring__bindgen_ty_1__bindgen_ty_1)
+        )
+    );
+    assert_eq!(
+        ::core::mem::align_of::<io_uring_buf_ring__bindgen_ty_1__bindgen_ty_1>(),
+        8usize,
+        concat!(
+            "Alignment of ",
+            stringify!(io_uring_buf_ring__bindgen_ty_1__bindgen_ty_1)
+        )
+    );
+    fn test_field_resv1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<
+                    io_uring_buf_ring__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).resv1) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(io_uring_buf_ring__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(resv1)
+            )
+        );
+    }
+    test_field_resv1();
+    fn test_field_resv2() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<
+                    io_uring_buf_ring__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).resv2) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(io_uring_buf_ring__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(resv2)
+            )
+        );
+    }
+    test_field_resv2();
+    fn test_field_resv3() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<
+                    io_uring_buf_ring__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).resv3) as usize - ptr as usize
+            },
+            12usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(io_uring_buf_ring__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(resv3)
+            )
+        );
+    }
+    test_field_resv3();
+    fn test_field_tail() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<
+                    io_uring_buf_ring__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).tail) as usize - ptr as usize
+            },
+            14usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(io_uring_buf_ring__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(tail)
+            )
+        );
+    }
+    test_field_tail();
+}
+#[test]
+fn bindgen_test_layout_io_uring_buf_ring__bindgen_ty_1() {
+    assert_eq!(
+        ::core::mem::size_of::<io_uring_buf_ring__bindgen_ty_1>(),
+        16usize,
+        concat!("Size of: ", stringify!(io_uring_buf_ring__bindgen_ty_1))
+    );
+    assert_eq!(
+        ::core::mem::align_of::<io_uring_buf_ring__bindgen_ty_1>(),
+        8usize,
+        concat!("Alignment of ", stringify!(io_uring_buf_ring__bindgen_ty_1))
+    );
+    fn test_field_bufs() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<io_uring_buf_ring__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).bufs) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(io_uring_buf_ring__bindgen_ty_1),
+                "::",
+                stringify!(bufs)
+            )
+        );
+    }
+    test_field_bufs();
+}
+impl Default for io_uring_buf_ring__bindgen_ty_1 {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[test]
+fn bindgen_test_layout_io_uring_buf_ring() {
+    assert_eq!(
+        ::core::mem::size_of::<io_uring_buf_ring>(),
+        16usize,
+        concat!("Size of: ", stringify!(io_uring_buf_ring))
+    );
+    assert_eq!(
+        ::core::mem::align_of::<io_uring_buf_ring>(),
+        8usize,
+        concat!("Alignment of ", stringify!(io_uring_buf_ring))
+    );
+}
+impl Default for io_uring_buf_ring {
+    fn default() -> Self {
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct io_uring_buf_reg {
+    pub ring_addr: __u64,
+    pub ring_entries: __u32,
+    pub bgid: __u16,
+    pub pad: __u16,
+    pub resv: [__u64; 3usize],
+}
+#[test]
+fn bindgen_test_layout_io_uring_buf_reg() {
+    assert_eq!(
+        ::core::mem::size_of::<io_uring_buf_reg>(),
+        40usize,
+        concat!("Size of: ", stringify!(io_uring_buf_reg))
+    );
+    assert_eq!(
+        ::core::mem::align_of::<io_uring_buf_reg>(),
+        8usize,
+        concat!("Alignment of ", stringify!(io_uring_buf_reg))
+    );
+    fn test_field_ring_addr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<io_uring_buf_reg>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).ring_addr) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(io_uring_buf_reg),
+                "::",
+                stringify!(ring_addr)
+            )
+        );
+    }
+    test_field_ring_addr();
+    fn test_field_ring_entries() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<io_uring_buf_reg>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).ring_entries) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(io_uring_buf_reg),
+                "::",
+                stringify!(ring_entries)
+            )
+        );
+    }
+    test_field_ring_entries();
+    fn test_field_bgid() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<io_uring_buf_reg>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).bgid) as usize - ptr as usize
+            },
+            12usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(io_uring_buf_reg),
+                "::",
+                stringify!(bgid)
+            )
+        );
+    }
+    test_field_bgid();
+    fn test_field_pad() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<io_uring_buf_reg>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).pad) as usize - ptr as usize
+            },
+            14usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(io_uring_buf_reg),
+                "::",
+                stringify!(pad)
+            )
+        );
+    }
+    test_field_pad();
+    fn test_field_resv() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<io_uring_buf_reg>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).resv) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(io_uring_buf_reg),
+                "::",
+                stringify!(resv)
+            )
+        );
+    }
+    test_field_resv();
+}
+pub const IORING_RESTRICTION_REGISTER_OP: _bindgen_ty_8 = 0;
+pub const IORING_RESTRICTION_SQE_OP: _bindgen_ty_8 = 1;
+pub const IORING_RESTRICTION_SQE_FLAGS_ALLOWED: _bindgen_ty_8 = 2;
+pub const IORING_RESTRICTION_SQE_FLAGS_REQUIRED: _bindgen_ty_8 = 3;
+pub const IORING_RESTRICTION_LAST: _bindgen_ty_8 = 4;
+pub type _bindgen_ty_8 = libc::c_uint;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct io_uring_getevents_arg {


### PR DESCRIPTION
Add support for IORING_SETUP_SQE128 and IORING_SETUP_CQE32, and add an `UringCmd` opcode corresponding to IORING_OP_URING_CMD.

These changes should be backward-compatible.