### PR TITLE
Implement I/O safety traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [ "io-uring-test", "io-uring-bench" ]
 unstable = []
 overwrite = [ "bindgen" ]
 direct-syscall = [ "sc" ]
+io_safety = []
 
 [dependencies]
 bitflags = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub use cqueue::CompletionQueue;
 pub use register::Probe;
 pub use squeue::SubmissionQueue;
 pub use submit::Submitter;
-use util::{OwnedFd, Mmap};
+use util::{Mmap, OwnedFd};
 
 /// IoUring instance
 pub struct IoUring {

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -4,7 +4,7 @@ use std::{io, ptr};
 
 use crate::register::{execute, Probe};
 use crate::sys;
-use crate::util::{cast_ptr, Fd};
+use crate::util::{cast_ptr, OwnedFd};
 use crate::Parameters;
 
 #[cfg(feature = "unstable")]
@@ -19,7 +19,7 @@ use crate::types;
 /// io_uring supports both directly performing I/O on buffers and file descriptors and registering
 /// them beforehand. Registering is slow, but it makes performing the actual I/O much faster.
 pub struct Submitter<'a> {
-    fd: &'a Fd,
+    fd: &'a OwnedFd,
     params: &'a Parameters,
 
     sq_head: *const atomic::AtomicU32,
@@ -30,7 +30,7 @@ pub struct Submitter<'a> {
 impl<'a> Submitter<'a> {
     #[inline]
     pub(crate) const fn new(
-        fd: &'a Fd,
+        fd: &'a OwnedFd,
         params: &'a Parameters,
         sq_head: *const atomic::AtomicU32,
         sq_tail: *const atomic::AtomicU32,

--- a/src/util.rs
+++ b/src/util.rs
@@ -69,7 +69,7 @@ mod fd {
 #[cfg(not(feature = "io_safety"))]
 mod fd {
     use std::mem;
-    use std::os::unix::io::{AsRawFd, RawFd, IntoRawFd, FromRawFd};
+    use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 
     /// API-compatible with the `OwnedFd` type in the Rust stdlib.
     pub struct OwnedFd(RawFd);

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,6 @@
-use std::convert::TryFrom;
-use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+use std::os::unix::io::AsRawFd;
 use std::sync::atomic;
-use std::{io, mem, ptr};
+use std::{io, ptr};
 
 /// A region of memory mapped using `mmap(2)`.
 pub struct Mmap {
@@ -60,49 +59,119 @@ impl Drop for Mmap {
     }
 }
 
-/// An owned file descriptor.
-pub struct Fd(pub RawFd);
+pub use fd::Fd;
 
-impl TryFrom<RawFd> for Fd {
-    type Error = ();
+#[cfg(feature = "io_safety")]
+mod fd {
+    use std::os::unix::io::{AsRawFd, RawFd, IntoRawFd, FromRawFd, OwnedFd, AsFd, BorrowedFd};
 
-    #[inline]
-    fn try_from(value: RawFd) -> Result<Fd, Self::Error> {
-        if value >= 0 {
-            Ok(Fd(value))
-        } else {
-            Err(())
+    /// An owned file descriptor.
+    pub struct Fd(pub OwnedFd);
+
+    impl Fd {
+        /// Try to convert from a `RawFd` to an `Fd`.
+        /// 
+        /// # Safety
+        /// 
+        /// Must be a valid file descriptor.
+        pub unsafe fn from_raw(value: RawFd) -> Option<Fd> {
+            if value >= 0 {
+                // SAFETY: not -1, and this is a valid FD
+                Some(Fd(OwnedFd::from_raw_fd(value)))
+            } else {
+                None
+            }
+        }       
+    }
+
+    impl AsRawFd for Fd {
+        fn as_raw_fd(&self) -> RawFd {
+            self.0.as_raw_fd()
+        }
+    }
+
+    impl IntoRawFd for Fd {
+        fn into_raw_fd(self) -> RawFd {
+            self.0.into_raw_fd()
+        }
+    }
+
+    impl FromRawFd for Fd {
+        unsafe fn from_raw_fd(fd: RawFd) -> Self {
+            Fd(OwnedFd::from_raw_fd(fd))
+        }
+    }
+
+    impl AsFd for Fd {
+        fn as_fd(&self) -> BorrowedFd<'_> {
+            self.0.as_fd()
+        }
+    }
+
+    impl From<OwnedFd> for Fd {
+        fn from(fd: OwnedFd) -> Self {
+            Fd(fd)
+        }
+    }
+
+    impl From<Fd> for OwnedFd {
+        fn from(fd: Fd) -> Self {
+            fd.0
         }
     }
 }
 
-impl AsRawFd for Fd {
-    #[inline]
-    fn as_raw_fd(&self) -> RawFd {
-        self.0
-    }
-}
+#[cfg(not(feature = "io_safety"))]
+mod fd {
+    use std::mem;
+    use std::os::unix::io::{AsRawFd, RawFd, IntoRawFd, FromRawFd};
 
-impl IntoRawFd for Fd {
-    #[inline]
-    fn into_raw_fd(self) -> RawFd {
-        let fd = self.0;
-        mem::forget(self);
-        fd
-    }
-}
+    /// An owned file descriptor.
+    pub struct Fd(pub RawFd);
 
-impl FromRawFd for Fd {
-    #[inline]
-    unsafe fn from_raw_fd(fd: RawFd) -> Fd {
-        Fd(fd)
+    impl Fd {
+        /// Try to convert from a `RawFd` to an `Fd`.
+        /// 
+        /// # Safety
+        /// 
+        /// Must be a valid file descriptor.
+        pub unsafe fn from_raw(value: RawFd) -> Option<Fd> {
+            if value >= 0 {
+                Some(Fd(value))
+            } else {
+                None
+            }
+        }
     }
-}
 
-impl Drop for Fd {
-    fn drop(&mut self) {
-        unsafe {
-            libc::close(self.0);
+    impl AsRawFd for Fd {
+        #[inline]
+        fn as_raw_fd(&self) -> RawFd {
+            self.0
+        }
+    }
+
+    impl IntoRawFd for Fd {
+        #[inline]
+        fn into_raw_fd(self) -> RawFd {
+            let fd = self.0;
+            mem::forget(self);
+            fd
+        }
+    }
+
+    impl FromRawFd for Fd {
+        #[inline]
+        unsafe fn from_raw_fd(fd: RawFd) -> Fd {
+            Fd(fd)
+        }
+    }
+
+    impl Drop for Fd {
+        fn drop(&mut self) {
+            unsafe {
+                libc::close(self.0);
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request adds a new `io_safety` feature that uses the `AsFd` trait from Rust 1.63. In addition, the `Fd` utility type is implemented using `OwnedFd` for its niching.

See also: sunfishcode/io-lifetimes#38