### PR TITLE
fix test_file_fallocate

### DIFF
--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -80,6 +80,7 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     tests::fs::test_file_fsync(&mut ring, &test)?;
     tests::fs::test_file_fsync_file_range(&mut ring, &test)?;
     tests::fs::test_file_fallocate(&mut ring, &test)?;
+    tests::fs::test_file_fallocate64(&mut ring, &test)?;
     tests::fs::test_file_openat2(&mut ring, &test)?;
     tests::fs::test_file_close(&mut ring, &test)?;
     #[cfg(not(feature = "ci"))]

--- a/io-uring-test/src/tests/fs.rs
+++ b/io-uring-test/src/tests/fs.rs
@@ -144,6 +144,31 @@ pub fn test_file_fallocate<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
             .expect("queue is full");
     }
 
+    ring.submit_and_wait(1)?;
+
+    let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
+
+    assert_eq!(cqes.len(), 1);
+    assert_eq!(cqes[0].user_data(), 0x10);
+    assert_eq!(cqes[0].result(), 0);
+
+    Ok(())
+}
+
+pub fn test_file_fallocate64<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
+    require!(
+        test;
+        test.probe.is_supported(opcode::Fallocate64::CODE);
+    );
+
+    println!("test file_fallocate64");
+
+    let fd = tempfile::tempfile()?;
+    let fd = types::Fd(fd.as_raw_fd());
+
     let falloc_e = opcode::Fallocate64::new(fd, 1024);
 
     unsafe {
@@ -152,15 +177,13 @@ pub fn test_file_fallocate<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
             .expect("queue is full");
     }
 
-    ring.submit_and_wait(2)?;
+    ring.submit_and_wait(1)?;
 
     let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
 
-    assert_eq!(cqes.len(), 2);
-    assert_eq!(cqes[0].user_data(), 0x10);
+    assert_eq!(cqes.len(), 1);
+    assert_eq!(cqes[0].user_data(), 0x20);
     assert_eq!(cqes[0].result(), 0);
-    assert_eq!(cqes[1].user_data(), 0x20);
-    assert_eq!(cqes[1].result(), 0);
 
     Ok(())
 }


### PR DESCRIPTION
Split the test_file_fallocate function into two, one that tests the now deprecated opcode::Fallocate and another that tests the new opcode::Fallocate64.

By putting one submission per function, there is only one completion expected for each, so no ordering issue.

Fixes #141