### PR TITLE
add register_files_sparse

### DIFF
--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -73,6 +73,9 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     #[cfg(feature = "unstable")]
     tests::queue::test_batch(&mut ring, &test)?;
 
+    // register
+    tests::register::test_register_files_sparse(&mut ring, &test)?;
+
     // fs
     tests::fs::test_file_write_read(&mut ring, &test)?;
     tests::fs::test_file_writev_readv(&mut ring, &test)?;

--- a/io-uring-test/src/tests/mod.rs
+++ b/io-uring-test/src/tests/mod.rs
@@ -2,4 +2,5 @@ pub mod fs;
 pub mod net;
 pub mod poll;
 pub mod queue;
+pub mod register;
 pub mod timeout;

--- a/io-uring-test/src/tests/register.rs
+++ b/io-uring-test/src/tests/register.rs
@@ -1,0 +1,71 @@
+use crate::Test;
+use io_uring::{cqueue, opcode, squeue, IoUring};
+
+pub fn test_register_files_sparse<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
+    // register_files_sparse was introduced in kernel 5.19, as was the opcode for UringCmd16.
+    // So require the UringCmd16 to avoid running this test on earlier kernels.
+    require!(
+        test;
+        test.probe.is_supported(opcode::UringCmd16::CODE);
+    );
+
+    println!("test register_files_sparse");
+
+    ring.submitter().register_files_sparse(4)?;
+
+
+    // See that same call again, with any value, will fail because a direct table cannot be built
+    // over an existing one.
+
+    if let Ok(()) = ring.submitter().register_files_sparse(3) {
+        return Err(anyhow::anyhow!(
+            "register_files_sparse should not have succeeded twice in a row"
+        ));
+    }
+
+    // See that the direct table can be removed.
+
+    if let Err(e) = ring.submitter().unregister_files() {
+        return Err(anyhow::anyhow!("unrgister_files failed: {}", e));
+    }
+
+    // See that a second attempt to remove the direct table would fail.
+
+    if let Ok(()) = ring.submitter().unregister_files() {
+        return Err(anyhow::anyhow!(
+            "unrgister_files should not have succeeded twice in a row"
+        ));
+    }
+
+    // See that a new, large, direct table can be created.
+    // If it fails with EMFILE, print the ulimit command for changing this.
+
+    if let Err(e) = ring.submitter().register_files_sparse(10_000) {
+        if let Some(raw_os_err) = e.raw_os_error() {
+            if raw_os_err == libc::EMFILE {
+                println!(
+                    "could not open 10,000 file descriptors, try `ulimit -Sn 11000` in the shell"
+                );
+                return Ok(());
+            } else {
+                return Err(anyhow::anyhow!("register_files_sparse should have succeeded after the previous one was removed: {}", e));
+            }
+        } else {
+            return Err(anyhow::anyhow!("register_files_sparse should have succeeded after the previous one was removed: {}", e));
+        }
+    }
+
+    // And removed.
+
+    if let Err(e) = ring.submitter().unregister_files() {
+        return Err(anyhow::anyhow!(
+            "unrgister_files failed, odd since the one could be unregistered earlier: {}",
+            e
+        ));
+    }
+
+    Ok(())
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -70,8 +70,8 @@ pub struct epoll_event {
 pub struct Fd(pub RawFd);
 
 /// A file descriptor that has been registered with io_uring using
-/// [`Submitter::register_files`](crate::Submitter::register_files). This can reduce overhead
-/// compared to using [`Fd`] in some cases.
+/// [`Submitter::register_files`](crate::Submitter::register_files) or [`Submitter::register_files_sparse`](crate::Submitter::register_files_sparse).
+/// This can reduce overhead compared to using [`Fd`] in some cases.
 #[derive(Debug, Clone, Copy)]
 #[repr(transparent)]
 pub struct Fixed(pub u32);


### PR DESCRIPTION
The ability to register a completely sparse file descriptor table is introduced with the 5.19 kernel.

Also, a register test module is added with a single test for the new register_files_sparse submitter method. Besides testing that the method can be run without error, it tests that unregister_files works by checking that the register form cannot be done twice in a row and it checks that the unregister form cannot be done twice in a row.