### PR TITLE
Add IORING_OP_SEND_ZC opcode

### DIFF
--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -107,6 +107,7 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     tests::net::test_tcp_write_read(&mut ring, &test)?;
     tests::net::test_tcp_writev_readv(&mut ring, &test)?;
     tests::net::test_tcp_send_recv(&mut ring, &test)?;
+    tests::net::test_tcp_zero_copy_send_recv(&mut ring, &test)?;
     tests::net::test_tcp_sendmsg_recvmsg(&mut ring, &test)?;
     tests::net::test_tcp_accept(&mut ring, &test)?;
     tests::net::test_tcp_connect(&mut ring, &test)?;

--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -107,6 +107,7 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     tests::net::test_tcp_write_read(&mut ring, &test)?;
     tests::net::test_tcp_writev_readv(&mut ring, &test)?;
     tests::net::test_tcp_send_recv(&mut ring, &test)?;
+    #[cfg(feature = "unstable")]
     tests::net::test_tcp_zero_copy_send_recv(&mut ring, &test)?;
     tests::net::test_tcp_sendmsg_recvmsg(&mut ring, &test)?;
     tests::net::test_tcp_accept(&mut ring, &test)?;

--- a/io-uring-test/src/tests/net.rs
+++ b/io-uring-test/src/tests/net.rs
@@ -113,6 +113,7 @@ pub fn test_tcp_send_recv<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     Ok(())
 }
 
+#[cfg(feature = "unstable")]
 pub fn test_tcp_zero_copy_send_recv<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     ring: &mut IoUring<S, C>,
     test: &Test,

--- a/io-uring-test/src/tests/net.rs
+++ b/io-uring-test/src/tests/net.rs
@@ -161,18 +161,18 @@ pub fn test_tcp_zero_copy_send_recv<S: squeue::EntryMarker, C: cqueue::EntryMark
     assert_eq!(cqes[0].result(), text.len() as i32);
 
     // Notification is not ordered w.r.t recv
-    match(cqes[1].user_data(), cqes[2].user_data()){
+    match (cqes[1].user_data(), cqes[2].user_data()) {
         (0x01, 0x02) => {
             assert!(!io_uring::cqueue::more(cqes[1].flags()));
             assert_eq!(cqes[2].result(), text.len() as i32);
             assert_eq!(&output[..cqes[2].result() as usize], text);
-        },
+        }
         (0x02, 0x01) => {
             assert!(!io_uring::cqueue::more(cqes[2].flags()));
             assert_eq!(cqes[1].result(), text.len() as i32);
             assert_eq!(&output[..cqes[1].result() as usize], text);
         }
-        _ => assert!(false)
+        _ => assert!(false),
     }
     Ok(())
 }

--- a/src/cqueue.rs
+++ b/src/cqueue.rs
@@ -329,6 +329,6 @@ pub fn buffer_select(flags: u32) -> Option<u16> {
 }
 
 #[cfg(feature = "unstable")]
-pub fn more(flags: u32) -> bool{
+pub fn more(flags: u32) -> bool {
     flags & sys::IORING_CQE_F_MORE != 0
 }

--- a/src/cqueue.rs
+++ b/src/cqueue.rs
@@ -327,3 +327,8 @@ pub fn buffer_select(flags: u32) -> Option<u16> {
         None
     }
 }
+
+#[cfg(feature = "unstable")]
+pub fn more(flags: u32) -> bool{
+    flags & sys::IORING_CQE_F_MORE != 0
+}

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1441,3 +1441,33 @@ opcode!(
         Entry128(Entry(sqe), cmd2)
     }
 );
+
+// === 6.0 ===
+
+#[cfg(feature = "unstable")]
+opcode!(
+    /// Send a zerocopy message on a socket, equivalent to `send(2)`.
+    pub struct SendZc {
+        fd: { impl sealed::UseFixed },
+        buf: { *const u8 },
+        len: { u32 },
+        ;;
+        flags: i32 = 0,
+        zc_flags: u16 =0,
+    }
+
+    pub const CODE = sys::IORING_OP_SEND_ZC;
+
+    pub fn build(self) -> Entry {
+        let SendZc { fd, buf, len, flags, zc_flags } = self;
+
+        let mut sqe = sqe_zeroed();
+        sqe.opcode = Self::CODE;
+        assign_fd!(sqe.fd = fd);
+        sqe.__bindgen_anon_2.addr = buf as _;
+        sqe.len = len;
+        sqe.__bindgen_anon_3.msg_flags = flags as _;
+        sqe.ioprio = zc_flags;
+        Entry(sqe)
+    }
+);

--- a/src/sys/sys.rs
+++ b/src/sys/sys.rs
@@ -110,6 +110,7 @@ pub const IORING_ACCEPT_MULTISHOT: u32 = 1;
 pub const IORING_CQE_F_BUFFER: u32 = 1;
 pub const IORING_CQE_F_MORE: u32 = 2;
 pub const IORING_CQE_F_SOCK_NONEMPTY: u32 = 4;
+pub const IORING_CQE_F_NOTIF: u32 = 8;
 pub const IORING_OFF_SQ_RING: u32 = 0;
 pub const IORING_OFF_CQ_RING: u32 = 134217728;
 pub const IORING_OFF_SQES: u32 = 268435456;
@@ -1229,7 +1230,8 @@ pub const IORING_OP_FGETXATTR: io_uring_op = 43;
 pub const IORING_OP_GETXATTR: io_uring_op = 44;
 pub const IORING_OP_SOCKET: io_uring_op = 45;
 pub const IORING_OP_URING_CMD: io_uring_op = 46;
-pub const IORING_OP_LAST: io_uring_op = 47;
+pub const IORING_OP_SEND_ZC: io_uring_op = 47;
+pub const IORING_OP_LAST: io_uring_op = 48;
 pub type io_uring_op = libc::c_uint;
 #[repr(C)]
 #[derive(Debug, Default)]


### PR DESCRIPTION
Adds support for IORING_OP_SEND_ZC opcode introduced in linux 6.0.

Also exposes `IO_URING_ZQE_F_NOTIF` and `IO_URING_ZQE_F_MORE`, to be able to implement completion handling for zerocopy send, which may return multiple CQE's per submission.