### PR TITLE
Split (Submission/Completion)Queue::sync into 2 different functions

### DIFF
--- a/src/cqueue.rs
+++ b/src/cqueue.rs
@@ -111,6 +111,20 @@ impl<E: EntryMarker> CompletionQueue<'_, E> {
         }
     }
 
+    /// Flush any entries consumed in this iterator.
+    #[cfg(feature = "unstable")]
+    #[inline]
+    pub fn flush(&self) {
+        unsafe { (*self.queue.head).store(self.head, atomic::Ordering::Release) };
+    }
+
+    /// Load new entries in the queue if the kernel has produced some entries in the meantime.
+    #[cfg(feature = "unstable")]
+    #[inline]
+    pub fn load(&mut self) {
+        unsafe { self.tail = (*self.queue.tail).load(atomic::Ordering::Acquire); }
+    }
+
     /// If queue is full and [`is_feature_nodrop`](crate::Parameters::is_feature_nodrop) is not set,
     /// new events may be dropped. This records the number of dropped events.
     pub fn overflow(&self) -> u32 {

--- a/src/cqueue.rs
+++ b/src/cqueue.rs
@@ -115,14 +115,18 @@ impl<E: EntryMarker> CompletionQueue<'_, E> {
     #[cfg(feature = "unstable")]
     #[inline]
     pub fn flush(&self) {
-        unsafe { (*self.queue.head).store(self.head, atomic::Ordering::Release) };
+        unsafe {
+            (*self.queue.head).store(self.head, atomic::Ordering::Release);
+        }
     }
 
     /// Load new entries in the queue if the kernel has produced some entries in the meantime.
     #[cfg(feature = "unstable")]
     #[inline]
     pub fn load(&mut self) {
-        unsafe { self.tail = (*self.queue.tail).load(atomic::Ordering::Acquire); }
+        unsafe {
+            self.tail = (*self.queue.tail).load(atomic::Ordering::Acquire);
+        }
     }
 
     /// If queue is full and [`is_feature_nodrop`](crate::Parameters::is_feature_nodrop) is not set,

--- a/src/squeue.rs
+++ b/src/squeue.rs
@@ -185,6 +185,26 @@ impl<E: EntryMarker> SubmissionQueue<'_, E> {
         }
     }
 
+    /// This will flush any entries added by [`push`](Self::push) or
+    /// [`push_multiple`](Self::push_multiple)
+    #[cfg(feature = "unstable")]
+    #[inline]
+    pub fn flush(&self) {
+        unsafe {
+            (*self.queue.tail).store(self.tail, atomic::Ordering::Release);
+        }
+    }
+
+    /// Update the queue's length if the kernel has consumed some
+    /// entries in the meantime.
+    #[cfg(feature = "unstable")]
+    #[inline]
+    pub fn load(&mut self) {
+        unsafe {
+            self.head = (*self.queue.head).load(atomic::Ordering::Acquire);
+        }
+    }
+
     /// When [`is_setup_sqpoll`](crate::Parameters::is_setup_sqpoll) is set, whether the kernel
     /// threads has gone to sleep and requires a system call to wake it up.
     #[inline]


### PR DESCRIPTION
The reason behind this PR is that you rarely need to do both operations at once.

As an example, consider the following code:
```rust
let mut cq = unsafe { rt.io_uring.completion_shared() };

if cq.is_empty() {
    rt.io_uring.submit_and_wait(1)
        .expect("submit_and_wait");

    cq.sync();
}

while let Some(cqe) = cq.next() {
    todo!();
}
```
In this case `CompletionQueue::sync` is being used to load new CQE's. Therefore `(*self.queue.head).store(self.head, atomic::Ordering::Release);` is unnecessary. It will be executed in the `CompletionQueue` destructor after CQE's are consumed.