### PR TITLE
io-uring-test: clippy and --no-default-features

### DIFF
--- a/io-uring-test/src/tests/fs.rs
+++ b/io-uring-test/src/tests/fs.rs
@@ -508,6 +508,7 @@ pub fn test_file_direct_write_read<S: squeue::EntryMarker, C: cqueue::EntryMarke
     Ok(())
 }
 
+#[cfg(feature = "unstable")]
 pub fn test_file_splice<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     ring: &mut IoUring<S, C>,
     test: &Test,

--- a/io-uring-test/src/tests/net.rs
+++ b/io-uring-test/src/tests/net.rs
@@ -172,7 +172,7 @@ pub fn test_tcp_zero_copy_send_recv<S: squeue::EntryMarker, C: cqueue::EntryMark
             assert_eq!(cqes[1].result(), text.len() as i32);
             assert_eq!(&output[..cqes[1].result() as usize], text);
         }
-        _ => assert!(false),
+        _ => unreachable!(),
     }
     Ok(())
 }

--- a/io-uring-test/src/tests/timeout.rs
+++ b/io-uring-test/src/tests/timeout.rs
@@ -302,9 +302,7 @@ pub fn test_timeout_submit_args<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     }
     assert_eq!(start.elapsed().as_secs(), 1);
 
-    let cqes = ring.completion().collect::<Vec<_>>();
-
-    assert!(cqes.is_empty());
+    assert!(ring.completion().next().is_none());
 
     // no timeout
 


### PR DESCRIPTION
Cleanup for

    cd io-uring-test
    cargo clippy
    cargo run --no-default-features