### PR TITLE
add IORING_SETUP_COOP_TASKRUN flag to builder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,6 +370,12 @@ impl<S: squeue::EntryMarker, C: cqueue::EntryMarker> Builder<S, C> {
         self
     }
 
+    #[cfg(feature = "unstable")]
+    pub fn setup_coop_taskrun(&mut self) -> &mut Self {
+        self.params.flags |= sys::IORING_SETUP_COOP_TASKRUN;
+        self
+    }
+
     /// Build an [IoUring], with the specified number of entries in the submission queue and
     /// completion queue unless [`setup_cqsize`](Self::setup_cqsize) has been called.
     pub fn build(&self, entries: u32) -> io::Result<IoUring<S, C>> {


### PR DESCRIPTION
From the manpages

> IORING_SETUP_COOP_TASKRUN
              By  default, io_uring will interrupt a task running in userspace when a completion event comes in. This is to ensure that completions run in a timely manner. For a lot of use cases, this is overkill
              and can cause reduced performance from both the inter-processor interrupt used to do this, the kernel/user transition, the needless interruption of the tasks userspace activities, and reduced batch‐
              ing  if completions come in at a rapid rate. Most applications don't need the forceful interruption, as the events are processed at any kernel/user transition. The exception are setups where the ap‐
              plication uses multiple threads operating on the same ring, where the application waiting on completions isn't the one that submitted them. For most other use cases, setting this flag  will  improve
              performance. Available since 5.19.

I've added just this flag, there's also `IORING_SETUP_TASKRUN_FLAG` which provides a SQ flag to indicate there are completions to be processed. This will need a builder method and a method on SubmissionQueue.

