### PR TITLE
Avoid std::ptr::addr_of! in BufRingEntry::tail to support stable Debian

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -263,7 +263,8 @@ impl BufRingEntry {
     /// so the caller is responsible for passing in a valid pointer. And not just
     /// a valid pointer type, but also the argument must be the address to the first entry
     /// of the buf_ring for the resv field to even be considered the tail field of the ring.
+    /// The entry must also be properly initialized.
     pub unsafe fn tail(ring_base: *const BufRingEntry) -> *const u16 {
-        std::ptr::addr_of!((*ring_base).0.resv)
+        &(*ring_base).0.resv
     }
 }


### PR DESCRIPTION
Debian bullseye (the current stable release) is still on Rust 1.48. Thankfully, `(*ring_base).0.resv` will always be 2-byte aligned, so we can just get a reference to it and coerce that into a pointer.