### PR TITLE
Drop the "unstable" feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           command: test
           use-cross: true
-          args: --features unstable --target ${{ matrix.target }}
+          args: --target ${{ matrix.target }}
       - uses: actions-rs/cargo@v1
         with:
           command: run
@@ -80,7 +80,7 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --target ${{ matrix.target }} --features unstable
+          args: --target ${{ matrix.target }}
 
 
   fmt:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,3 @@ bindgen = { version = "0.60", optional = true }
 anyhow = "1"
 socket2 = "0.4"
 slab = "0.4"
-
-[package.metadata.docs.rs]
-features = [ "unstable" ]

--- a/io-uring-bench/Cargo.toml
+++ b/io-uring-bench/Cargo.toml
@@ -6,10 +6,6 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[features]
-default = [ "unstable" ]
-unstable = [ "io-uring/unstable" ]
-
 [dependencies]
 io-uring = { path = ".." }
 iou = "0.3"

--- a/io-uring-bench/src/iai_new_nop.rs
+++ b/io-uring-bench/src/iai_new_nop.rs
@@ -26,7 +26,6 @@ fn bench_io_uring() {
     }
 }
 
-#[cfg(feature = "unstable")]
 fn bench_io_uring_batch() {
     use io_uring::{opcode, IoUring};
     use std::mem;
@@ -188,18 +187,9 @@ fn bench_uring_sys_batch() {
     }
 }
 
-#[cfg(feature = "unstable")]
 iai::main!(
     bench_io_uring,
     bench_io_uring_batch,
-    bench_iou,
-    bench_uring_sys,
-    bench_uring_sys_batch
-);
-
-#[cfg(not(feature = "unstable"))]
-iai::main!(
-    bench_io_uring,
     bench_iou,
     bench_uring_sys,
     bench_uring_sys_batch

--- a/io-uring-test/Cargo.toml
+++ b/io-uring-test/Cargo.toml
@@ -15,7 +15,5 @@ once_cell = "1"
 socket2 = "0.4"
 
 [features]
-default = [ "unstable" ]
-unstable = [ "io-uring/unstable" ]
 direct-syscall = [ "io-uring/direct-syscall" ]
 ci = []

--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -14,7 +14,7 @@ fn main() -> anyhow::Result<()> {
 
     test::<squeue::Entry, cqueue::Entry>(IoUring::new(entries)?)?;
 
-    #[cfg(all(feature = "unstable", not(feature = "ci")))]
+    #[cfg(not(feature = "ci"))]
     {
         match IoUring::<squeue::Entry128, cqueue::Entry>::generic_new(entries) {
             Ok(r) => test(r)?,
@@ -70,13 +70,10 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     tests::queue::test_queue_split(&mut ring, &test)?;
     tests::queue::test_debug_print(&mut ring, &test)?;
 
-    #[cfg(feature = "unstable")]
     tests::queue::test_batch(&mut ring, &test)?;
 
     // register
-    #[cfg(feature = "unstable")]
     tests::register::test_register_files_sparse(&mut ring, &test)?;
-    #[cfg(feature = "unstable")]
     tests::register_buf_ring::test_register_buf_ring(&mut ring, &test)?;
 
     // fs
@@ -93,7 +90,6 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     tests::fs::test_file_direct_write_read(&mut ring, &test)?;
     #[cfg(not(feature = "ci"))]
     tests::fs::test_statx(&mut ring, &test)?;
-    #[cfg(feature = "unstable")]
     tests::fs::test_file_splice(&mut ring, &test)?;
 
     // timeout
@@ -102,19 +98,16 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     tests::timeout::test_timeout_remove(&mut ring, &test)?;
     tests::timeout::test_timeout_cancel(&mut ring, &test)?;
     tests::timeout::test_timeout_abs(&mut ring, &test)?;
-    #[cfg(feature = "unstable")]
     tests::timeout::test_timeout_submit_args(&mut ring, &test)?;
 
     // net
     tests::net::test_tcp_write_read(&mut ring, &test)?;
     tests::net::test_tcp_writev_readv(&mut ring, &test)?;
     tests::net::test_tcp_send_recv(&mut ring, &test)?;
-    #[cfg(feature = "unstable")]
     tests::net::test_tcp_zero_copy_send_recv(&mut ring, &test)?;
     tests::net::test_tcp_sendmsg_recvmsg(&mut ring, &test)?;
     tests::net::test_tcp_accept(&mut ring, &test)?;
     tests::net::test_tcp_connect(&mut ring, &test)?;
-    #[cfg(feature = "unstable")]
     tests::net::test_tcp_buffer_select(&mut ring, &test)?;
 
     // queue

--- a/io-uring-test/src/tests/fs.rs
+++ b/io-uring-test/src/tests/fs.rs
@@ -508,7 +508,6 @@ pub fn test_file_direct_write_read<S: squeue::EntryMarker, C: cqueue::EntryMarke
     Ok(())
 }
 
-#[cfg(feature = "unstable")]
 pub fn test_file_splice<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     ring: &mut IoUring<S, C>,
     test: &Test,

--- a/io-uring-test/src/tests/mod.rs
+++ b/io-uring-test/src/tests/mod.rs
@@ -3,6 +3,5 @@ pub mod net;
 pub mod poll;
 pub mod queue;
 pub mod register;
-#[cfg(feature = "unstable")]
 pub mod register_buf_ring;
 pub mod timeout;

--- a/io-uring-test/src/tests/net.rs
+++ b/io-uring-test/src/tests/net.rs
@@ -113,7 +113,6 @@ pub fn test_tcp_send_recv<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     Ok(())
 }
 
-#[cfg(feature = "unstable")]
 pub fn test_tcp_zero_copy_send_recv<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     ring: &mut IoUring<S, C>,
     test: &Test,
@@ -351,7 +350,6 @@ pub fn test_tcp_connect<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     Ok(())
 }
 
-#[cfg(feature = "unstable")]
 pub fn test_tcp_buffer_select<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     ring: &mut IoUring<S, C>,
     test: &Test,

--- a/io-uring-test/src/tests/queue.rs
+++ b/io-uring-test/src/tests/queue.rs
@@ -29,7 +29,6 @@ pub fn test_nop<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     Ok(())
 }
 
-#[cfg(feature = "unstable")]
 pub fn test_batch<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     ring: &mut IoUring<S, C>,
     test: &Test,

--- a/io-uring-test/src/tests/register.rs
+++ b/io-uring-test/src/tests/register.rs
@@ -1,9 +1,6 @@
-#[cfg(feature = "unstable")]
 use crate::Test;
-#[cfg(feature = "unstable")]
 use io_uring::{cqueue, opcode, squeue, IoUring};
 
-#[cfg(feature = "unstable")]
 pub fn test_register_files_sparse<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     ring: &mut IoUring<S, C>,
     test: &Test,

--- a/io-uring-test/src/tests/timeout.rs
+++ b/io-uring-test/src/tests/timeout.rs
@@ -277,7 +277,6 @@ pub fn test_timeout_abs<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     Ok(())
 }
 
-#[cfg(feature = "unstable")]
 pub fn test_timeout_submit_args<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     ring: &mut IoUring<S, C>,
     test: &Test,

--- a/src/cqueue.rs
+++ b/src/cqueue.rs
@@ -2,7 +2,6 @@
 
 use std::fmt::{self, Debug};
 use std::mem;
-#[cfg(feature = "unstable")]
 use std::mem::MaybeUninit;
 use std::sync::atomic;
 
@@ -49,7 +48,6 @@ pub trait EntryMarker: Clone + Debug + Into<Entry> + Sealed {}
 pub struct Entry(pub(crate) sys::io_uring_cqe);
 
 /// A 32-byte completion queue entry (CQE), representing a complete I/O operation.
-#[cfg(feature = "unstable")]
 #[repr(C)]
 #[derive(Clone)]
 pub struct Entry32(pub(crate) Entry, pub(crate) [u64; 2]);
@@ -57,7 +55,6 @@ pub struct Entry32(pub(crate) Entry, pub(crate) [u64; 2]);
 #[test]
 fn test_entry_sizes() {
     assert_eq!(mem::size_of::<Entry>(), 16);
-    #[cfg(feature = "unstable")]
     assert_eq!(mem::size_of::<Entry32>(), 32);
 }
 
@@ -120,9 +117,6 @@ impl<E: EntryMarker> CompletionQueue<'_, E> {
     /// Whether eventfd notifications are disabled when a request is completed and queued to the CQ
     /// ring. This library currently does not provide a way to set it, so this will always be
     /// `false`.
-    ///
-    /// Requires the `unstable` feature.
-    #[cfg(feature = "unstable")]
     pub fn eventfd_disabled(&self) -> bool {
         unsafe {
             (*self.queue.flags).load(atomic::Ordering::Acquire) & sys::IORING_CQ_EVENTFD_DISABLED
@@ -150,7 +144,6 @@ impl<E: EntryMarker> CompletionQueue<'_, E> {
         self.len() == self.capacity()
     }
 
-    #[cfg(feature = "unstable")]
     #[inline]
     pub fn fill<'a>(&mut self, entries: &'a mut [MaybeUninit<E>]) -> &'a mut [E] {
         let len = std::cmp::min(self.len(), entries.len());
@@ -254,7 +247,6 @@ impl Debug for Entry {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl Entry32 {
     /// The operation-specific result code. For example, for a [`Read`](crate::opcode::Read)
     /// operation this is equivalent to the return value of the `read(2)` system call.
@@ -287,22 +279,18 @@ impl Entry32 {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl Sealed for Entry32 {
     const ADDITIONAL_FLAGS: u32 = sys::IORING_SETUP_CQE32;
 }
 
-#[cfg(feature = "unstable")]
 impl EntryMarker for Entry32 {}
 
-#[cfg(feature = "unstable")]
 impl From<Entry32> for Entry {
     fn from(entry32: Entry32) -> Self {
         entry32.0
     }
 }
 
-#[cfg(feature = "unstable")]
 impl Debug for Entry32 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Entry32")
@@ -314,7 +302,6 @@ impl Debug for Entry32 {
     }
 }
 
-#[cfg(feature = "unstable")]
 pub fn buffer_select(flags: u32) -> Option<u16> {
     if flags & sys::IORING_CQE_F_BUFFER != 0 {
         let id = flags >> sys::IORING_CQE_BUFFER_SHIFT;
@@ -328,7 +315,6 @@ pub fn buffer_select(flags: u32) -> Option<u16> {
     }
 }
 
-#[cfg(feature = "unstable")]
 pub fn more(flags: u32) -> bool {
     flags & sys::IORING_CQE_F_MORE != 0
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,6 @@ impl<S: squeue::EntryMarker, C: cqueue::EntryMarker> IoUring<S, C> {
     ///
     /// Unlike [`IoUring::new`], this function is available for any combination of submission queue
     /// entry (SQE) and completion queue entry (CQE) types.
-    #[cfg(feature = "unstable")]
     pub fn generic_new(entries: u32) -> io::Result<Self> {
         Self::generic_builder().build(entries)
     }
@@ -113,7 +112,6 @@ impl<S: squeue::EntryMarker, C: cqueue::EntryMarker> IoUring<S, C> {
     /// Unlike [`IoUring::builder`], this function is available for any combination of submission
     /// queue entry (SQE) and completion queue entry (CQE) types.
     #[must_use]
-    #[cfg(feature = "unstable")]
     pub fn generic_builder() -> Builder<S, C> {
         Builder {
             dontfork: false,
@@ -362,15 +360,11 @@ impl<S: squeue::EntryMarker, C: cqueue::EntryMarker> Builder<S, C> {
     /// events. You are only able to [register restrictions](Submitter::register_restrictions) when
     /// the rings are disabled due to concurrency issues. You can enable the rings with
     /// [`Submitter::register_enable_rings`].
-    ///
-    /// Requires the `unstable` feature.
-    #[cfg(feature = "unstable")]
     pub fn setup_r_disabled(&mut self) -> &mut Self {
         self.params.flags |= sys::IORING_SETUP_R_DISABLED;
         self
     }
 
-    #[cfg(feature = "unstable")]
     pub fn setup_coop_taskrun(&mut self) -> &mut Self {
         self.params.flags |= sys::IORING_SETUP_COOP_TASKRUN;
         self
@@ -453,9 +447,6 @@ impl Parameters {
     /// See [the commit message that introduced
     /// it](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=d7718a9d25a61442da8ee8aeeff6a0097f0ccfd6)
     /// for more details.
-    ///
-    /// Requires the `unstable` feature.
-    #[cfg(feature = "unstable")]
     pub fn is_feature_fast_poll(&self) -> bool {
         self.0.features & sys::IORING_FEAT_FAST_POLL != 0
     }
@@ -466,17 +457,14 @@ impl Parameters {
         self.0.features & sys::IORING_FEAT_POLL_32BITS != 0
     }
 
-    #[cfg(feature = "unstable")]
     pub fn is_feature_sqpoll_nonfixed(&self) -> bool {
         self.0.features & sys::IORING_FEAT_SQPOLL_NONFIXED != 0
     }
 
-    #[cfg(feature = "unstable")]
     pub fn is_feature_ext_arg(&self) -> bool {
         self.0.features & sys::IORING_FEAT_EXT_ARG != 0
     }
 
-    #[cfg(feature = "unstable")]
     pub fn is_feature_native_workers(&self) -> bool {
         self.0.features & sys::IORING_FEAT_NATIVE_WORKERS != 0
     }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2,13 +2,11 @@
 
 #![allow(clippy::new_without_default)]
 
-#[cfg(feature = "unstable")]
 use std::convert::TryInto;
 use std::mem;
 use std::os::unix::io::RawFd;
 
 use crate::squeue::Entry;
-#[cfg(feature = "unstable")]
 use crate::squeue::Entry128;
 use crate::sys;
 use crate::types::{self, sealed};
@@ -1129,13 +1127,10 @@ opcode!(
     }
 );
 
-#[cfg(feature = "unstable")]
 opcode!(
     /// Register `nbufs` buffers that each have the length `len` with ids starting from `big` in the
     /// group `bgid` that can be used for any request. See
     /// [`BUFFER_SELECT`](crate::squeue::Flags::BUFFER_SELECT) for more info.
-    ///
-    /// Requires the `unstable` feature.
     pub struct ProvideBuffers {
         addr: { *mut u8 },
         len: { i32 },
@@ -1161,12 +1156,9 @@ opcode!(
     }
 );
 
-#[cfg(feature = "unstable")]
 opcode!(
     /// Remove some number of buffers from a buffer group. See
     /// [`BUFFER_SELECT`](crate::squeue::Flags::BUFFER_SELECT) for more info.
-    ///
-    /// Requires the `unstable` feature.
     pub struct RemoveBuffers {
         nbufs: { u16 },
         bgid: { u16 }
@@ -1188,11 +1180,8 @@ opcode!(
 
 // === 5.8 ===
 
-#[cfg(feature = "unstable")]
 opcode!(
     /// Duplicate pipe content, equivalent to `tee(2)`.
-    ///
-    /// Requires the `unstable` feature.
     pub struct Tee {
         fd_in: { impl sealed::UseFixed },
         fd_out: { impl sealed::UseFixed },
@@ -1228,7 +1217,6 @@ opcode!(
 
 // === 5.11 ===
 
-#[cfg(feature = "unstable")]
 opcode!(
     pub struct Shutdown {
         fd: { impl sealed::UseFixed },
@@ -1249,7 +1237,6 @@ opcode!(
     }
 );
 
-#[cfg(feature = "unstable")]
 opcode!(
     pub struct RenameAt {
         olddirfd: { impl sealed::UseFd },
@@ -1280,7 +1267,6 @@ opcode!(
     }
 );
 
-#[cfg(feature = "unstable")]
 opcode!(
     pub struct UnlinkAt {
         dirfd: { impl sealed::UseFd },
@@ -1305,11 +1291,8 @@ opcode!(
 
 // === 5.15 ===
 
-#[cfg(feature = "unstable")]
 opcode!(
     /// Make a directory, equivalent to `mkdirat2(2)`.
-    ///
-    /// Requires the `unstable` feature.
     pub struct MkDirAt {
         dirfd: { impl sealed::UseFd },
         pathname: { *const libc::c_char },
@@ -1331,11 +1314,8 @@ opcode!(
     }
 );
 
-#[cfg(feature = "unstable")]
 opcode!(
     /// Create a symlink, equivalent to `symlinkat2(2)`.
-    ///
-    /// Requires the `unstable` feature.
     pub struct SymlinkAt {
         newdirfd: { impl sealed::UseFd },
         target: { *const libc::c_char },
@@ -1357,11 +1337,8 @@ opcode!(
     }
 );
 
-#[cfg(feature = "unstable")]
 opcode!(
     /// Create a hard link, equivalent to `linkat2(2)`.
-    ///
-    /// Requires the `unstable` feature.
     pub struct LinkAt {
         olddirfd: { impl sealed::UseFd },
         oldpath: { *const libc::c_char },
@@ -1389,7 +1366,6 @@ opcode!(
 
 // === 5.19 ===
 
-#[cfg(feature = "unstable")]
 opcode!(
     /// A file/device-specific 16-byte command, akin (but not equivalent) to `ioctl(2)`.
     pub struct UringCmd16 {
@@ -1414,7 +1390,6 @@ opcode!(
     }
 );
 
-#[cfg(feature = "unstable")]
 opcode!(
     /// A file/device-specific 80-byte command, akin (but not equivalent) to `ioctl(2)`.
     pub struct UringCmd80 {
@@ -1444,7 +1419,6 @@ opcode!(
 
 // === 6.0 ===
 
-#[cfg(feature = "unstable")]
 opcode!(
     /// Send a zerocopy message on a socket, equivalent to `send(2)`.
     pub struct SendZc {

--- a/src/register.rs
+++ b/src/register.rs
@@ -111,20 +111,15 @@ impl Drop for Probe {
 
 /// An allowed feature of io_uring. You can set the allowed features with
 /// [`register_restrictions`](crate::Submitter::register_restrictions).
-///
-/// Requires the `unstable` feature.
-#[cfg(feature = "unstable")]
 #[repr(transparent)]
 pub struct Restriction(sys::io_uring_restriction);
 
 /// inline zeroed to improve codegen
-#[cfg(feature = "unstable")]
 #[inline(always)]
 fn res_zeroed() -> sys::io_uring_restriction {
     unsafe { std::mem::zeroed() }
 }
 
-#[cfg(feature = "unstable")]
 impl Restriction {
     /// Allow an `io_uring_register` opcode.
     pub fn register_op(op: u8) -> Restriction {
@@ -165,5 +160,4 @@ impl Restriction {
 ///
 /// File descriptors can be skipped if they are set to `SKIP_FILE`.
 /// Skipping an fd will not touch the file associated with the previous fd at that index.
-#[cfg(feature = "unstable")]
 pub const SKIP_FILE: RawFd = sys::IORING_REGISTER_FILES_SKIP;

--- a/src/squeue.rs
+++ b/src/squeue.rs
@@ -51,7 +51,6 @@ pub struct Entry(pub(crate) sys::io_uring_sqe);
 /// A 128-byte submission queue entry (SQE), representing a request for an I/O operation.
 ///
 /// These can be created via opcodes in [`opcode`](crate::opcode).
-#[cfg(feature = "unstable")]
 #[repr(C)]
 #[derive(Clone)]
 pub struct Entry128(pub(crate) Entry, pub(crate) [u8; 64]);
@@ -59,7 +58,6 @@ pub struct Entry128(pub(crate) Entry, pub(crate) [u8; 64]);
 #[test]
 fn test_entry_sizes() {
     assert_eq!(mem::size_of::<Entry>(), 64);
-    #[cfg(feature = "unstable")]
     assert_eq!(mem::size_of::<Entry128>(), 128);
 }
 
@@ -116,15 +114,9 @@ bitflags! {
         ///
         /// See also [the LWN thread on automatic buffer
         /// selection](https://lwn.net/Articles/815491/).
-        ///
-        /// Requires the `unstable` feature.
-        #[cfg(feature = "unstable")]
         const BUFFER_SELECT = 1 << sys::IOSQE_BUFFER_SELECT_BIT;
 
         /// Don't post CQE if request succeeded.
-        ///
-        /// Requires the `unstable` feature.
-        #[cfg(feature = "unstable")]
         const SKIP_SUCCESS = 1 << sys::IOSQE_CQE_SKIP_SUCCESS_BIT;
     }
 }
@@ -263,7 +255,6 @@ impl<E: EntryMarker> SubmissionQueue<'_, E> {
     /// Developers must ensure that parameters of all the entries (such as buffer) are valid and
     /// will be valid for the entire duration of the operation, otherwise it may cause memory
     /// problems.
-    #[cfg(feature = "unstable")]
     #[inline]
     pub unsafe fn push_multiple(&mut self, entries: &[E]) -> Result<(), PushError> {
         if self.capacity() - self.len() < entries.len() {
@@ -312,9 +303,6 @@ impl Entry {
 
     /// Set the personality of this event. You can obtain a personality using
     /// [`Submitter::register_personality`](crate::Submitter::register_personality).
-    ///
-    /// Requires the `unstable` feature.
-    #[cfg(feature = "unstable")]
     pub fn personality(mut self, personality: u16) -> Entry {
         self.0.personality = personality;
         self
@@ -344,7 +332,6 @@ impl Debug for Entry {
     }
 }
 
-#[cfg(feature = "unstable")]
 impl Entry128 {
     /// Set the submission event's [flags](Flags).
     #[inline]
@@ -363,31 +350,24 @@ impl Entry128 {
 
     /// Set the personality of this event. You can obtain a personality using
     /// [`Submitter::register_personality`](crate::Submitter::register_personality).
-    ///
-    /// Requires the `unstable` feature.
-    #[cfg(feature = "unstable")]
     pub fn personality(mut self, personality: u16) -> Entry128 {
         self.0 .0.personality = personality;
         self
     }
 }
 
-#[cfg(feature = "unstable")]
 impl Sealed for Entry128 {
     const ADDITIONAL_FLAGS: u32 = sys::IORING_SETUP_SQE128;
 }
 
-#[cfg(feature = "unstable")]
 impl EntryMarker for Entry128 {}
 
-#[cfg(feature = "unstable")]
 impl From<Entry> for Entry128 {
     fn from(entry: Entry) -> Entry128 {
         Entry128(entry, [0u8; 64])
     }
 }
 
-#[cfg(feature = "unstable")]
 impl Debug for Entry128 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("Entry128")

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -7,10 +7,8 @@ use crate::sys;
 use crate::util::{cast_ptr, OwnedFd};
 use crate::Parameters;
 
-#[cfg(feature = "unstable")]
 use crate::register::Restriction;
 
-#[cfg(feature = "unstable")]
 use crate::types;
 
 /// Interface for submitting submission queue events in an io_uring instance to the kernel for
@@ -144,7 +142,6 @@ impl<'a> Submitter<'a> {
         unsafe { self.enter::<libc::sigset_t>(len as _, want as _, flags, None) }
     }
 
-    #[cfg(feature = "unstable")]
     pub fn submit_with_args(
         &self,
         want: usize,
@@ -171,9 +168,6 @@ impl<'a> Submitter<'a> {
     }
 
     /// Wait for the submission queue to have free entries.
-    ///
-    /// Requires the `unstable` feature.
-    #[cfg(feature = "unstable")]
     pub fn squeue_wait(&self) -> io::Result<usize> {
         unsafe { self.enter::<libc::sigset_t>(0, 0, sys::IORING_ENTER_SQ_WAIT, None) }
     }
@@ -196,9 +190,6 @@ impl<'a> Submitter<'a> {
     ///
     /// Registering a file table is a prerequisite for using any request that
     /// uses direct descriptors.
-    ///
-    /// Requires the `unstable` feature.
-    #[cfg(feature = "unstable")]
     pub fn register_files_sparse(&self, nr: u32) -> io::Result<()> {
         use std::mem;
         let rr = sys::io_uring_rsrc_register {
@@ -385,9 +376,6 @@ impl<'a> Submitter<'a> {
     /// an operation not on the allowlist will fail with `-EACCES`.
     ///
     /// This can only be called once, to prevent untrusted code from removing restrictions.
-    ///
-    /// Requires the `unstable` feature.
-    #[cfg(feature = "unstable")]
     pub fn register_restrictions(&self, res: &mut [Restriction]) -> io::Result<()> {
         execute(
             self.fd.as_raw_fd(),
@@ -400,9 +388,6 @@ impl<'a> Submitter<'a> {
 
     /// Enable the rings of the io_uring instance if they have been disabled with
     /// [`setup_r_disabled`](crate::Builder::setup_r_disabled).
-    ///
-    /// Requires the `unstable` feature.
-    #[cfg(feature = "unstable")]
     pub fn register_enable_rings(&self) -> io::Result<()> {
         execute(
             self.fd.as_raw_fd(),
@@ -420,9 +405,6 @@ impl<'a> Submitter<'a> {
     /// which carry out I/O operations that can never complete, for instance I/O
     /// on sockets. Passing `0` does not change the current limit. Returns
     /// previous limits on success.
-    ///
-    /// Requires the `unstable` feature.
-    #[cfg(feature = "unstable")]
     pub fn register_iowq_max_workers(&self, max: &mut [u32; 2]) -> io::Result<()> {
         execute(
             self.fd.as_raw_fd(),
@@ -441,9 +423,6 @@ impl<'a> Submitter<'a> {
     /// 32768, the InvalidInput error is returned.
     ///
     /// Available since 5.19.
-    ///
-    /// Requires the `unstable` feature.
-    #[cfg(feature = "unstable")]
     pub fn register_buf_ring(
         &self,
         ring_addr: u64,
@@ -474,9 +453,6 @@ impl<'a> Submitter<'a> {
     /// Unregister a previously registered buffer ring.
     ///
     /// Available since 5.19.
-    ///
-    /// Requires the `unstable` feature.
-    #[cfg(feature = "unstable")]
     pub fn unregister_buf_ring(&self, bgid: u16) -> io::Result<()> {
         let arg = sys::io_uring_buf_reg {
             ring_addr: 0,

--- a/src/types.rs
+++ b/src/types.rs
@@ -44,10 +44,8 @@ use crate::sys;
 use bitflags::bitflags;
 use std::os::unix::io::RawFd;
 
-#[cfg(feature = "unstable")]
 use std::marker::PhantomData;
 
-#[cfg(feature = "unstable")]
 use crate::util::cast_ptr;
 
 pub use sys::__kernel_rwf_t as RwFlags;
@@ -81,7 +79,6 @@ bitflags! {
     pub struct TimeoutFlags: u32 {
         const ABS = sys::IORING_TIMEOUT_ABS;
 
-        #[cfg(feature = "unstable")]
         const UPDATE = sys::IORING_TIMEOUT_UPDATE;
     }
 }
@@ -169,7 +166,6 @@ impl Timespec {
 ///
 /// drop(args);
 /// ```
-#[cfg(feature = "unstable")]
 #[derive(Default, Debug, Clone, Copy)]
 pub struct SubmitArgs<'prev: 'now, 'now> {
     pub(crate) args: sys::io_uring_getevents_arg,
@@ -177,7 +173,6 @@ pub struct SubmitArgs<'prev: 'now, 'now> {
     now: PhantomData<&'now ()>,
 }
 
-#[cfg(feature = "unstable")]
 impl<'prev, 'now> SubmitArgs<'prev, 'now> {
     #[inline]
     pub const fn new() -> SubmitArgs<'static, 'static> {
@@ -219,12 +214,10 @@ impl<'prev, 'now> SubmitArgs<'prev, 'now> {
     }
 }
 
-#[cfg(feature = "unstable")]
 #[repr(transparent)]
 pub struct BufRingEntry(sys::io_uring_buf);
 
 /// An entry in a buf_ring that allows setting the address, length and buffer id.
-#[cfg(feature = "unstable")]
 impl BufRingEntry {
     /// Sets the entry addr.
     pub fn set_addr(&mut self, addr: u64) {


### PR DESCRIPTION
This is a proposal to drop the "unstable" feature.

Dependent crates that rely on "unstable" functionality need to restrict the set of supported io-uring versions to a predetermined closed range (e.g. >=0.5.6, <=0.5.8), just in case a future release breaks compatibility. This makes io-uring version incompatibilities in a dependency graph more likely, and can complicate packaging for distributions (see https://bugzilla.redhat.com/show_bug.cgi?id=2124697#c76 for an example).

Let's rely on the fact that we're pre-1.0 to safely try out new APIs instead.

Since we're removing a feature, this will require a bump to 0.6.0. Alternatively, we can keep the feature but make it functionless.