### PR TITLE
Also run CI 'check' job again Rust 1.48

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,6 +62,9 @@ jobs:
       fail-fast: false
 
       matrix:
+        toolchain:
+          - nightly
+          - "1.48"
         target:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
@@ -73,7 +76,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly
+            toolchain: ${{ matrix.toolchain }}
             target: ${{ matrix.target }}
             components: clippy
             override: true


### PR DESCRIPTION
This should help maintain compatibility with stable Debian, which is still on Rust 1.48.