### PR TITLE
fix io-uring-test: remove unnecessary line

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "io-uring"
-version = "0.5.10"
+version = "0.5.11"
 authors = ["quininer <quininer@live.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/io-uring-test/src/tests/register_buf_ring.rs
+++ b/io-uring-test/src/tests/register_buf_ring.rs
@@ -488,7 +488,6 @@ where
     S: squeue::EntryMarker,
     C: cqueue::EntryMarker,
 {
-    _ = ring;
     // Create a BufRing
     // Register it
     // Unregister it


### PR DESCRIPTION
An unnecessary line seems to have been left in a test case from when the
function was first being developed that both does nothing for the test
now and worse, doesn't seem to compile with older rustc compilers.

This removes it.

And bumps version to 0.5.11.

Fixes #164.