### PR TITLE
opcode: add support for IORING_OP_MSG_RING

### DIFF
--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -69,6 +69,7 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     tests::queue::test_nop(&mut ring, &test)?;
     tests::queue::test_queue_split(&mut ring, &test)?;
     tests::queue::test_debug_print(&mut ring, &test)?;
+    tests::queue::test_msg_ring_data(&mut ring, &test)?;
 
     tests::queue::test_batch(&mut ring, &test)?;
 

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1369,6 +1369,39 @@ opcode!(
     }
 );
 
+// === 5.18 ===
+
+opcode!(
+    /// Send a message (with data) to a target ring.
+    pub struct MsgRingData {
+        ring_fd: { impl sealed::UseFd },
+        result: { i32 },
+        user_data: { u64 },
+        user_flags: { Option<u32> },
+        ;;
+        opcode_flags: u32 = 0
+    }
+
+    pub const CODE = sys::IORING_OP_MSG_RING;
+
+    pub fn build(self) -> Entry {
+        let MsgRingData { ring_fd, result, user_data, user_flags, opcode_flags } = self;
+
+        let mut sqe = sqe_zeroed();
+        sqe.opcode = Self::CODE;
+        sqe.__bindgen_anon_2.addr = sys::IORING_MSG_DATA.into();
+        sqe.fd = ring_fd;
+        sqe.len = result as u32;
+        sqe.__bindgen_anon_1.off = user_data;
+        sqe.__bindgen_anon_3.msg_ring_flags = opcode_flags;
+        if let Some(_flags) = user_flags {
+            // TODO(lucab): add IORING_MSG_RING_FLAGS_PASS support (in v6.3):
+            // https://lore.kernel.org/all/20230103160507.617416-1-leitao@debian.org/t/#u
+        }
+        Entry(sqe)
+    }
+);
+
 // === 5.19 ===
 
 opcode!(


### PR DESCRIPTION
This adds a wrapper for the `IORING_OP_MSG_RING` opcode, which was introduced in Linux 5.18.
Notably, this only implements the data message kind (`IORING_MSG_DATA`), without the FD-sending features.

Ref: https://man7.org/linux/man-pages/man2/io_uring_enter2.2.html