### PR TITLE
chore: fix clippy 0.1.67 warnings

### DIFF
--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -20,8 +20,7 @@ fn main() -> anyhow::Result<()> {
             Ok(r) => test(r)?,
             Err(e) => {
                 println!(
-                    "IoUring::<squeue::Entry128, cqueue::Entry>::generic_new(entries) failed: {}",
-                    e
+                    "IoUring::<squeue::Entry128, cqueue::Entry>::generic_new(entries) failed: {e}"
                 );
                 println!("Assume kernel doesn't support the new entry sizes so remaining tests being skipped.");
                 return Ok(());
@@ -58,7 +57,7 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
             .unwrap(),
     );
     println!("params: {:#?}", ring.params());
-    println!("probe: {:?}", probe);
+    println!("probe: {probe:?}");
     println!();
 
     let test = Test {

--- a/io-uring-test/src/tests/queue.rs
+++ b/io-uring-test/src/tests/queue.rs
@@ -135,7 +135,7 @@ pub fn test_debug_print<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
                 .expect("queue is full");
         }
     }
-    println!("Full: {:?}", sq);
+    println!("Full: {sq:?}");
     drop(sq);
 
     ring.submit_and_wait(num_to_sub)?;

--- a/io-uring-test/src/tests/register_buf_ring.rs
+++ b/io-uring-test/src/tests/register_buf_ring.rs
@@ -134,7 +134,7 @@ impl InnerBufRing {
         }
 
         // entry_size is 16 bytes.
-        let entry_size = std::mem::size_of::<BufRingEntry>() as usize;
+        let entry_size = std::mem::size_of::<BufRingEntry>();
         assert_eq!(entry_size, 16);
         let ring_size = entry_size * (ring_entries as usize);
 
@@ -197,7 +197,7 @@ impl InnerBufRing {
                     // using buf_ring requires kernel 5.19 or greater.
                     return Err(io::Error::new(
                             io::ErrorKind::Other,
-                            format!("buf_ring.register returned {}, most likely indicating this kernel is not 5.19+", e),
+                            format!("buf_ring.register returned {e}, most likely indicating this kernel is not 5.19+"),
                             ));
                 }
                 Some(libc::EEXIST) => {
@@ -208,15 +208,14 @@ impl InnerBufRing {
                     return Err(io::Error::new(
                             io::ErrorKind::Other,
                             format!(
-                                "buf_ring.register returned `{}`, indicating the attempted buffer group id {} was already registered",
-                            e,
-                            bgid),
+                                "buf_ring.register returned `{e}`, indicating the attempted buffer group id {bgid} was already registered"
+                            ),
                         ));
                 }
                 _ => {
                     return Err(io::Error::new(
                         io::ErrorKind::Other,
-                        format!("buf_ring.register returned `{}` for group id {}", e, bgid),
+                        format!("buf_ring.register returned `{e}` for group id {bgid}"),
                     ));
                 }
             }


### PR DESCRIPTION
These are limited to the io-uring-test source. No clippy warnings from the main library or the benchmark.