### PR TITLE
opcode: add support for IORING_MSG_SEND_FD

### DIFF
--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -70,6 +70,7 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     tests::queue::test_queue_split(&mut ring, &test)?;
     tests::queue::test_debug_print(&mut ring, &test)?;
     tests::queue::test_msg_ring_data(&mut ring, &test)?;
+    tests::queue::test_msg_ring_send_fd(&mut ring, &test)?;
 
     tests::queue::test_batch(&mut ring, &test)?;
 

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1458,6 +1458,38 @@ opcode!(
 // === 6.0 ===
 
 opcode!(
+    /// Send a message (with fixed FD) to a target ring.
+    pub struct MsgRingSendFd {
+        ring_fd: { impl sealed::UseFd },
+        fixed_slot_src: { types::Fixed },
+        dest_slot_index: { types::DestinationSlot },
+        result: { i32 },
+        user_data: { u64 },
+        ;;
+        opcode_flags: u32 = 0
+    }
+
+    pub const CODE = sys::IORING_OP_MSG_RING;
+
+    pub fn build(self) -> Entry {
+        let MsgRingSendFd { ring_fd, fixed_slot_src, dest_slot_index, result, user_data, opcode_flags } = self;
+
+        let mut sqe = sqe_zeroed();
+        sqe.opcode = Self::CODE;
+        sqe.__bindgen_anon_2.addr = sys::IORING_MSG_SEND_FD.into();
+        sqe.fd = ring_fd;
+        sqe.len = result as u32;
+        sqe.__bindgen_anon_1.off = user_data;
+        unsafe { sqe.__bindgen_anon_6.__bindgen_anon_1.as_mut().addr3 = fixed_slot_src.0 as u64 };
+        sqe.__bindgen_anon_5.file_index = dest_slot_index.kernel_index_arg();
+        sqe.__bindgen_anon_3.msg_ring_flags = opcode_flags;
+        Entry(sqe)
+    }
+);
+
+// === 6.0 ===
+
+opcode!(
     /// Send a zerocopy message on a socket, equivalent to `send(2)`.
     pub struct SendZc {
         fd: { impl sealed::UseFixed },


### PR DESCRIPTION
This introduces a new `MsgRingSendFd` operation in order to wrap the combination of `IORING_OP_MSG_RING` plus `IORING_MSG_SEND_FD` (available since 6.0).