### PR TITLE
opcode: add support for IORING_OP_SOCKET

### DIFF
--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -116,6 +116,7 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     tests::net::test_tcp_buffer_select_recvmsg(&mut ring, &test)?;
     #[cfg(not(feature = "ci"))]
     tests::net::test_tcp_buffer_select_readv(&mut ring, &test)?;
+    tests::net::test_socket(&mut ring, &test)?;
 
     // queue
     tests::poll::test_eventfd_poll(&mut ring, &test)?;

--- a/io-uring-test/src/tests/net.rs
+++ b/io-uring-test/src/tests/net.rs
@@ -3,6 +3,7 @@ use crate::Test;
 use io_uring::{cqueue, opcode, squeue, types, IoUring};
 use once_cell::sync::OnceCell;
 use std::net::{TcpListener, TcpStream};
+use std::os::fd::FromRawFd;
 use std::os::unix::io::AsRawFd;
 use std::{io, mem};
 
@@ -765,6 +766,50 @@ pub fn test_tcp_buffer_select_readv<S: squeue::EntryMarker, C: cqueue::EntryMark
     assert_eq!(bid, INPUT_BID);
     // Test with buffer associated with the INPUT_BID.
     assert_eq!(&(buf[..]), &([0x7bu8; 512][..]));
+
+    Ok(())
+}
+
+pub fn test_socket<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
+    use socket2::{Domain, Protocol, Socket, Type};
+
+    require!(
+        test;
+        test.probe.is_supported(opcode::Socket::CODE);
+    );
+
+    println!("test socket");
+
+    // Open a UDP socket, through old-style `socket(2)` syscall.
+    // This is used both as a kernel sanity check, and for comparing the returned io-uring FD.
+    let plain_socket = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP)).unwrap();
+    let plain_fd = plain_socket.as_raw_fd();
+
+    let socket_fd_op = opcode::Socket::new(
+        Domain::IPV4.into(),
+        Type::DGRAM.into(),
+        Protocol::UDP.into(),
+    );
+    unsafe {
+        ring.submission()
+            .push(&socket_fd_op.build().user_data(42).into())
+            .expect("queue is full");
+    }
+    ring.submit_and_wait(1)?;
+
+    let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
+    assert_eq!(cqes.len(), 1);
+    assert_eq!(cqes[0].user_data(), 42);
+    assert_eq!(cqes[0].result(), plain_fd + 1);
+    assert_eq!(cqes[0].flags(), 0);
+
+    // Close both sockets, to avoid leaking FDs.
+    let io_uring_socket = unsafe { Socket::from_raw_fd(cqes[0].result()) };
+    drop(plain_socket);
+    drop(io_uring_socket);
 
     Ok(())
 }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1455,6 +1455,33 @@ opcode!(
     }
 );
 
+// === 5.19 ===
+
+opcode!(
+    /// Create an endpoint for communication, equivalent to `socket(2)`.
+    pub struct Socket {
+        domain: { i32 },
+        socket_type: { i32 },
+        protocol: { i32 },
+        ;;
+        flags: types::RwFlags = 0
+    }
+
+    pub const CODE = sys::IORING_OP_SOCKET;
+
+    pub fn build(self) -> Entry {
+        let Socket { domain, socket_type, protocol, flags } = self;
+
+        let mut sqe = sqe_zeroed();
+        sqe.opcode = Self::CODE;
+        sqe.fd = domain as _;
+        sqe.__bindgen_anon_1.off = socket_type as _;
+        sqe.len = protocol as _;
+        sqe.__bindgen_anon_3.rw_flags = flags;
+        Entry(sqe)
+    }
+);
+
 // === 6.0 ===
 
 opcode!(


### PR DESCRIPTION
This adds an ergonomic wrapper for the `IORING_OP_SOCKET` opcode,
which has been introduced in kernel 5.19.