### PR TITLE
cqueue: add docstrings for multishot and dynamic-buffer flags

### DIFF
--- a/src/cqueue.rs
+++ b/src/cqueue.rs
@@ -302,6 +302,11 @@ impl Debug for Entry32 {
     }
 }
 
+/// Return which dynamic buffer was used by this operation.
+///
+/// This corresponds to the `IORING_CQE_F_BUFFER` flag (and related bit-shifting),
+/// and it signals to the consumer which provided contains the result of this
+/// operation.
 pub fn buffer_select(flags: u32) -> Option<u16> {
     if flags & sys::IORING_CQE_F_BUFFER != 0 {
         let id = flags >> sys::IORING_CQE_BUFFER_SHIFT;
@@ -315,6 +320,12 @@ pub fn buffer_select(flags: u32) -> Option<u16> {
     }
 }
 
+/// Return whether further completion events will be submitted for
+/// this same operation.
+///
+/// This corresponds to the `IORING_CQE_F_MORE` flag, and it signals to
+/// the consumer that it should expect further CQE entries after this one,
+/// still from the same original SQE request (e.g. for multishot operations).
 pub fn more(flags: u32) -> bool {
     flags & sys::IORING_CQE_F_MORE != 0
 }


### PR DESCRIPTION
This adds some docstrings for `cqueue::buffer_select()` and `cqueue::more()`, in order to make them easier to discover (as their usage is basically required for multishot operations).