### PR TITLE
opcode: add "fixed file" support to accept

### DIFF
--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -110,6 +110,7 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     tests::net::test_tcp_sendmsg_recvmsg(&mut ring, &test)?;
     tests::net::test_tcp_zero_copy_sendmsg_recvmsg(&mut ring, &test)?;
     tests::net::test_tcp_accept(&mut ring, &test)?;
+    tests::net::test_tcp_accept_file_index(&mut ring, &test)?;
     tests::net::test_tcp_connect(&mut ring, &test)?;
     tests::net::test_tcp_buffer_select(&mut ring, &test)?;
     #[cfg(not(feature = "ci"))]

--- a/io-uring-test/src/tests/net.rs
+++ b/io-uring-test/src/tests/net.rs
@@ -405,6 +405,62 @@ pub fn test_tcp_accept<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     Ok(())
 }
 
+pub fn test_tcp_accept_file_index<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
+    require!(
+        test;
+        test.probe.is_supported(opcode::Accept::CODE);
+        test.probe.is_supported(opcode::Socket::CODE); // To get file_index
+    );
+
+    println!("test tcp_accept_file_index");
+
+    // Cleanup all fixed files (if any), then reserve five slots 0..=4.
+    let _ = ring.submitter().unregister_files();
+    ring.submitter().register_files_sparse(5).unwrap();
+
+    // begin <from accept unit test>
+
+    let listener = TCP_LISTENER.get_or_try_init(|| TcpListener::bind("127.0.0.1:0"))?;
+    let addr = listener.local_addr()?;
+    let fd = types::Fd(listener.as_raw_fd());
+
+    let _stream = TcpStream::connect(addr)?;
+
+    let mut sockaddr: libc::sockaddr = unsafe { mem::zeroed() };
+    let mut addrlen: libc::socklen_t = mem::size_of::<libc::sockaddr>() as _;
+
+    let dest_slot = types::DestinationSlot::try_from_slot_target(4).unwrap();
+    let accept_e = opcode::Accept::new(fd, &mut sockaddr, &mut addrlen);
+    let accept_e = accept_e.file_index(Some(dest_slot));
+
+    unsafe {
+        ring.submission()
+            .push(&accept_e.build().user_data(0x0e).into())
+            .expect("queue is full");
+    }
+
+    ring.submit_and_wait(1)?;
+
+    let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
+
+    assert_eq!(cqes.len(), 1);
+    assert_eq!(cqes[0].user_data(), 0x0e);
+    assert_eq!(cqes[0].result(), 0); // success iff result is zero.
+
+    // end of <from accept unit test>
+
+    // The new tcp stream socket, with fixed descriptor at [4], will be released when the files are
+    // unregistered.
+
+    // If the fixed-socket operation worked properly, this must not fail.
+    ring.submitter().unregister_files().unwrap();
+
+    Ok(())
+}
+
 pub fn test_tcp_connect<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     ring: &mut IoUring<S, C>,
     test: &Test,

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -565,13 +565,14 @@ opcode!(
         addr: { *mut libc::sockaddr },
         addrlen: { *mut libc::socklen_t },
         ;;
+        file_index: Option<types::DestinationSlot> = None,
         flags: i32 = 0
     }
 
     pub const CODE = sys::IORING_OP_ACCEPT;
 
     pub fn build(self) -> Entry {
-        let Accept { fd, addr, addrlen, flags } = self;
+        let Accept { fd, addr, addrlen, file_index, flags } = self;
 
         let mut sqe = sqe_zeroed();
         sqe.opcode = Self::CODE;
@@ -579,6 +580,9 @@ opcode!(
         sqe.__bindgen_anon_2.addr = addr as _;
         sqe.__bindgen_anon_1.addr2 = addrlen as _;
         sqe.__bindgen_anon_3.accept_flags = flags as _;
+        if let Some(dest) = file_index {
+            sqe.__bindgen_anon_5.file_index = dest.kernel_index_arg();
+        }
         Entry(sqe)
     }
 );


### PR DESCRIPTION
Following the model from the file_index builder method set in #179.

Addresses one of the opcodes highlighted in #178.

Includes a unit test.