### PR TITLE
opcode: add support for IORING_POLL_ADD_MULTI

### DIFF
--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -122,6 +122,8 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     tests::poll::test_eventfd_poll(&mut ring, &test)?;
     tests::poll::test_eventfd_poll_remove(&mut ring, &test)?;
     tests::poll::test_eventfd_poll_remove_failed(&mut ring, &test)?;
+    #[cfg(not(feature = "ci"))]
+    tests::poll::test_eventfd_poll_multi(&mut ring, &test)?;
 
     // regression test
     tests::regression::test_issue154(&mut ring, &test)?;

--- a/io-uring-test/src/tests/poll.rs
+++ b/io-uring-test/src/tests/poll.rs
@@ -178,3 +178,60 @@ pub fn test_eventfd_poll_remove_failed<S: squeue::EntryMarker, C: cqueue::EntryM
 
     Ok(())
 }
+
+// Multi-shot only available since 5.13.
+#[cfg(not(feature = "ci"))]
+pub fn test_eventfd_poll_multi<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
+    require!(
+        test;
+        test.probe.is_supported(opcode::PollAdd::CODE);
+        test.probe.is_supported(opcode::MkDirAt::CODE); // Available since 5.15 when the multi poll was available 5.13.
+    );
+
+    println!("test eventfd_poll_multi");
+
+    let mut fd = unsafe {
+        let fd = libc::eventfd(0, libc::EFD_CLOEXEC);
+
+        if fd == -1 {
+            return Err(io::Error::last_os_error().into());
+        }
+
+        File::from_raw_fd(fd)
+    };
+
+    let poll_e = opcode::PollAdd::new(types::Fd(fd.as_raw_fd()), libc::POLLIN as _).multi(true);
+
+    unsafe {
+        let mut queue = ring.submission();
+        queue
+            .push(&poll_e.build().user_data(0x04).into())
+            .expect("queue is full");
+    }
+
+    ring.submit()?;
+    thread::sleep(Duration::from_millis(200));
+    assert_eq!(ring.completion().len(), 0);
+
+    fd.write_all(&0x1u64.to_ne_bytes())?;
+    thread::sleep(Duration::from_millis(1)); // shouldn't be necessary but shouldn't hurt either
+    fd.write_all(&0x2u64.to_ne_bytes())?;
+    ring.submit_and_wait(2)?;
+
+    let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
+
+    assert_eq!(cqes.len(), 2);
+
+    assert_eq!(cqes[0].user_data(), 0x04);
+    assert!(io_uring::cqueue::more(cqes[0].flags()));
+    assert_eq!(cqes[0].result(), 1);
+
+    assert_eq!(cqes[1].user_data(), 0x04);
+    assert!(io_uring::cqueue::more(cqes[1].flags()));
+    assert_eq!(cqes[1].result(), 1);
+
+    Ok(())
+}

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -349,7 +349,12 @@ opcode!(
     /// Unlike poll or epoll without `EPOLLONESHOT`, this interface defaults to work in one shot mode.
     /// That is, once the poll operation is completed, it will have to be resubmitted.
     ///
-    /// Since 5.13, the multi-shot mode is available.
+    /// If multi is set, the poll will work in multi shot mode instead. That means it will
+    /// repeatedly trigger when the requested event becomes true, and hence multiple CQEs can be
+    /// generated from this single submission. The CQE flags field will have IORING_CQE_F_MORE set
+    /// on completion if the application should expect further CQE entries from the original
+    /// request. If this flag isn't set on completion, then the poll request has been terminated
+    /// and no further events will be generated. This mode is available since 5.13.
     #[derive(Debug)]
     pub struct PollAdd {
         /// The bits that may be set in `flags` are defined in `<poll.h>`,


### PR DESCRIPTION
Adds a `multi` optional field to the `PollAdd` opcode.