### PR TITLE
fix submit_with_args to match submit_and_wait

### DIFF
--- a/src/submit.rs
+++ b/src/submit.rs
@@ -144,7 +144,7 @@ impl<'a> Submitter<'a> {
         let len = self.sq_len();
         let mut flags = sys::IORING_ENTER_EXT_ARG;
 
-        if want > 0 {
+        if want > 0 || self.params.is_setup_iopoll() || self.sq_cq_overflow() {
             flags |= sys::IORING_ENTER_GETEVENTS;
         }
 


### PR DESCRIPTION
The public function `submit_with_args` had fallen behind in logic that I believe should be a duplicate of `submit_and_wait`.