### PR TITLE
ci: use host kernel for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
       - uses: actions-rs/cargo@v1
         with:
           command: test
@@ -30,7 +25,9 @@ jobs:
         with:
           command: run
           use-cross: true
-          args: --package io-uring-test --features io-uring-test/ci --target ${{ matrix.target }}
+          # Only run the test package on x86 until we find an ergonomic way 
+          # to virtualize aarch64
+          args: --package io-uring-test --features io-uring-test/ci --target x86_64-unknown-linux-gnu
 
   check-bench:
     runs-on: ubuntu-latest
@@ -84,7 +81,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --target ${{ matrix.target }}
-
 
   fmt:
     name: fmt

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,7 +1,0 @@
-[target.x86_64-unknown-linux-gnu]
-image = "quininer/cross-nk:x86_64-unknown-linux-gnu-0.0.4"
-runner = "qemu-system"
-
-[target.aarch64-unknown-linux-gnu]
-image = "quininer/cross-nk:aarch64-unknown-linux-gnu-0.0.4"
-runner = "qemu-system"


### PR DESCRIPTION
Until we find an ergonomic way to virtualize aarch64 within github
actions, let's stick with only running the test package on x86. Unit
tests will run on both architectures via cross.

This bumps the kernel version used for tests from 5.10 to 5.15. To run
newer kernel versions (and to reintroduce running the test package on
aarch64) we'll need to revisit virtualization with QEMU.