### PR TITLE
lib: make `register_buffers` unsafe

### DIFF
--- a/io-uring-test/src/tests/net.rs
+++ b/io-uring-test/src/tests/net.rs
@@ -206,7 +206,7 @@ pub fn test_tcp_zero_copy_send_fixed<S: squeue::EntryMarker, C: cqueue::EntryMar
         iov_len: buf0.len() as _,
     };
     let iovecs = [iovec];
-    ring.submitter().register_buffers(&iovecs).unwrap();
+    unsafe { ring.submitter().register_buffers(&iovecs).unwrap() };
 
     let text_len = text.len();
 

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -172,10 +172,9 @@ impl<'a> Submitter<'a> {
     ///
     /// # Safety
     ///
-    /// This function is unsafe because improper use may lead to memory problems.
-    /// For example, a use-after-free may occur if `iov_base` contains a pointer freed
-    /// before unregistering the buffer through [`unregister_buffers`](Self::unregister_buffers)
-    /// or [`register_buffers_update_tag`](Self::register_buffers_update_tag).
+    /// Developers must ensure that the `iov_base` and `iov_len` values are valid and will
+    /// be valid until buffers are unregistered or the ring destroyed, otherwise undefined
+    /// behaviour may occur.
     pub unsafe fn register_buffers(&self, bufs: &[libc::iovec]) -> io::Result<()> {
         execute(
             self.fd.as_raw_fd(),

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -166,10 +166,17 @@ impl<'a> Submitter<'a> {
         unsafe { self.enter::<libc::sigset_t>(0, 0, sys::IORING_ENTER_SQ_WAIT, None) }
     }
 
-    /// Register in-memory user buffers for I/O with the kernel. You can use these buffers with the
+    /// Register in-memory fixed buffers for I/O with the kernel. You can use these buffers with the
     /// [`ReadFixed`](crate::opcode::ReadFixed) and [`WriteFixed`](crate::opcode::WriteFixed)
     /// operations.
-    pub fn register_buffers(&self, bufs: &[libc::iovec]) -> io::Result<()> {
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because improper use may lead to memory problems.
+    /// For example, a use-after-free may occur if `iov_base` contains a pointer freed
+    /// before unregistering the buffer through [`unregister_buffers`](Self::unregister_buffers)
+    /// or [`register_buffers_update_tag`](Self::register_buffers_update_tag).
+    pub unsafe fn register_buffers(&self, bufs: &[libc::iovec]) -> io::Result<()> {
         execute(
             self.fd.as_raw_fd(),
             sys::IORING_REGISTER_BUFFERS,


### PR DESCRIPTION
This breaking change is required as calling `register_buffers` with incorrect inputs may introduce undefined behaviour.

This PR also changes the method documentation to use `fixed buffers` instead of `user buffers` to match the `io_uring` man pages terminology, related to #217.