### PR TITLE
Add support for IORING_REGISTER_SYNC_CANCEL

### DIFF
--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -77,7 +77,8 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     // register
     tests::register::test_register_files_sparse(&mut ring, &test)?;
     tests::register_buf_ring::test_register_buf_ring(&mut ring, &test)?;
-
+    tests::register_sync_cancel::test_register_sync_cancel(&mut ring, &test)?;
+    tests::register_sync_cancel::test_register_sync_cancel_unsubmitted(&mut ring, &test)?;
     // fs
     tests::fs::test_file_write_read(&mut ring, &test)?;
     tests::fs::test_file_writev_readv(&mut ring, &test)?;

--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -79,6 +79,7 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     tests::register_buf_ring::test_register_buf_ring(&mut ring, &test)?;
     tests::register_sync_cancel::test_register_sync_cancel(&mut ring, &test)?;
     tests::register_sync_cancel::test_register_sync_cancel_unsubmitted(&mut ring, &test)?;
+    tests::register_sync_cancel::test_register_sync_cancel_any(&mut ring, &test)?;
     // fs
     tests::fs::test_file_write_read(&mut ring, &test)?;
     tests::fs::test_file_writev_readv(&mut ring, &test)?;

--- a/io-uring-test/src/tests/mod.rs
+++ b/io-uring-test/src/tests/mod.rs
@@ -4,5 +4,6 @@ pub mod poll;
 pub mod queue;
 pub mod register;
 pub mod register_buf_ring;
+pub mod register_sync_cancel;
 pub mod regression;
 pub mod timeout;

--- a/io-uring-test/src/tests/register_sync_cancel.rs
+++ b/io-uring-test/src/tests/register_sync_cancel.rs
@@ -1,10 +1,9 @@
 use std::io;
-use std::time::{Duration, Instant};
 
 use io_uring::cqueue;
 use io_uring::opcode;
-use io_uring::squeue::{self, Flags};
-use io_uring::types::{self, AsyncCancelFlags, Timespec};
+use io_uring::squeue;
+use io_uring::types::{self, AsyncCancelFlags};
 use io_uring::IoUring;
 
 use crate::Test;
@@ -90,7 +89,7 @@ pub fn test_register_sync_cancel_unsubmitted<S: squeue::EntryMarker, C: cqueue::
     const USER_DATA: u64 = 42u64;
 
     let mut buf = [0u8; 32];
-    let mut entry = opcode::Read::new(types::Fd(0), buf.as_mut_ptr(), 32).build();
+    let entry = opcode::Read::new(types::Fd(0), buf.as_mut_ptr(), 32).build();
     unsafe { ring.submission().push(&entry.into()).unwrap() };
 
     // Cancel the operation by user_data, we haven't submitted anything yet.

--- a/io-uring-test/src/tests/register_sync_cancel.rs
+++ b/io-uring-test/src/tests/register_sync_cancel.rs
@@ -1,0 +1,106 @@
+use std::io;
+use std::time::{Duration, Instant};
+
+use io_uring::cqueue;
+use io_uring::opcode;
+use io_uring::squeue::{self, Flags};
+use io_uring::types::{self, AsyncCancelFlags, Timespec};
+use io_uring::IoUring;
+
+use crate::Test;
+
+pub fn test_register_sync_cancel<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> io::Result<()> {
+    require!(
+        test; // We need at least 5.19 for these tests, UringCmd16 is a proxy for that.
+        test.probe.is_supported(opcode::UringCmd16::CODE);
+    );
+    // Single op, canceled by the user_data
+    const USER_DATA_0: u64 = 42u64;
+    // 2 operations, canceled by the user_data
+    const USER_DATA_1: u64 = 43u64;
+    // 2 operations, canceled by the fd.
+    const USER_DATA_2: u64 = 44u64;
+
+    // Start reads for user_data_0
+    let mut buf = [0u8; 32];
+    for i in 0..5 {
+        let mut entry = opcode::Read::new(types::Fd(0), buf.as_mut_ptr(), 32).build();
+
+        if i == 0 {
+            entry = entry.user_data(USER_DATA_0);
+        } else if (1..3).contains(&i) {
+            entry = entry.user_data(USER_DATA_1);
+        } else if (3..5).contains(&i) {
+            entry = entry.user_data(USER_DATA_2);
+        }
+        unsafe { ring.submission().push(&entry.into()).unwrap() };
+    }
+    // Submit all 5 operations.
+    assert_eq!(5, ring.submit()?);
+
+    // Cancel the first operation by user_data
+    ring.submitter()
+        .register_sync_cancel(USER_DATA_0, -1, None, AsyncCancelFlags::empty())?;
+    ring.submitter().submit_and_wait(1)?;
+    let cqe: cqueue::Entry = ring.completion().next().unwrap().into();
+    assert_eq!(
+        cqe.result(),
+        -libc::ECANCELED,
+        "operation should have been canceled"
+    );
+    assert_eq!(cqe.user_data(), USER_DATA_0);
+
+    // Cancel the second two operations by their user data flags.
+    ring.submitter()
+        .register_sync_cancel(USER_DATA_1, -1, None, AsyncCancelFlags::ALL)?;
+    ring.submitter().submit_and_wait(2)?;
+    let cqe1: cqueue::Entry = ring.completion().next().unwrap().into();
+    let cqe2: cqueue::Entry = ring.completion().next().unwrap().into();
+    assert_eq!(cqe1.result(), cqe2.result());
+    assert_eq!(cqe1.result(), -libc::ECANCELED);
+
+    // Cancel the last two operations by their fd.
+    ring.submitter().register_sync_cancel(
+        USER_DATA_2,
+        0,
+        None,
+        AsyncCancelFlags::FD | AsyncCancelFlags::ALL,
+    )?;
+    ring.submitter().submit_and_wait(2)?;
+    let cqe1: cqueue::Entry = ring.completion().next().unwrap().into();
+    let cqe2: cqueue::Entry = ring.completion().next().unwrap().into();
+    assert_eq!(cqe1.result(), cqe2.result());
+    assert_eq!(cqe1.result(), -libc::ECANCELED);
+
+    Ok(())
+}
+
+pub fn test_register_sync_cancel_unsubmitted<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> io::Result<()> {
+    require!(
+        test; // We need at least 5.19 for these tests, UringCmd16 is a proxy for that.
+        test.probe.is_supported(opcode::UringCmd16::CODE);
+    );
+    // Test that we can cancel operations which have not yet been submitted.
+    const USER_DATA: u64 = 42u64;
+
+    let mut buf = [0u8; 32];
+    let mut entry = opcode::Read::new(types::Fd(0), buf.as_mut_ptr(), 32).build();
+    unsafe { ring.submission().push(&entry.into()).unwrap() };
+
+    // Cancel the operation by user_data, we haven't submitted anything yet.
+    ring.submitter()
+        .register_sync_cancel(USER_DATA, -1, None, AsyncCancelFlags::empty())?;
+
+    ring.submitter().submit_and_wait(1)?;
+    let cqe1: cqueue::Entry = ring.completion().next().unwrap().into();
+    assert_eq!(cqe1.result(), -libc::ECANCELED);
+    assert_eq!(cqe1.user_data(), USER_DATA);
+
+    Ok(())
+}

--- a/io-uring-test/src/tests/register_sync_cancel.rs
+++ b/io-uring-test/src/tests/register_sync_cancel.rs
@@ -83,7 +83,7 @@ pub fn test_register_sync_cancel_unsubmitted<S: squeue::EntryMarker, C: cqueue::
         test.probe.is_supported(opcode::SendZc::CODE);
     );
     // Test that we can cancel operations which have not yet been submitted.
-    const USER_DATA: u64 = 42u64;
+    const USER_DATA: u64 = 45u64;
 
     let mut buf = [0u8; 32];
     let entry = opcode::Read::new(types::Fd(0), buf.as_mut_ptr(), 32)

--- a/io-uring-test/src/tests/register_sync_cancel.rs
+++ b/io-uring-test/src/tests/register_sync_cancel.rs
@@ -1,5 +1,4 @@
 use std::io;
-use std::mem;
 use std::os::fd::AsRawFd;
 use std::os::fd::FromRawFd;
 use std::os::fd::OwnedFd;

--- a/io-uring-test/src/tests/register_sync_cancel.rs
+++ b/io-uring-test/src/tests/register_sync_cancel.rs
@@ -14,8 +14,8 @@ pub fn test_register_sync_cancel<S: squeue::EntryMarker, C: cqueue::EntryMarker>
     test: &Test,
 ) -> io::Result<()> {
     require!(
-        test; // We need at least 5.19 for these tests, UringCmd16 is a proxy for that.
-        test.probe.is_supported(opcode::UringCmd16::CODE);
+        test; // We need at least 6.0 to use `IORING_REGISTER_SYNC_CANCEL`. opcode::SendZc is a proxy for that requirement.
+        test.probe.is_supported(opcode::SendZc::CODE);
     );
     // Single op, canceled by the user_data
     const USER_DATA_0: u64 = 42u64;
@@ -79,7 +79,7 @@ pub fn test_register_sync_cancel_unsubmitted<S: squeue::EntryMarker, C: cqueue::
     test: &Test,
 ) -> io::Result<()> {
     require!(
-        test; // We need at least 6.0 to use `IORING_REGISTER_SYNC_CANCEL`. opcode::SendZc is a proxy for that requirement.
+        test;
         test.probe.is_supported(opcode::SendZc::CODE);
     );
     // Test that we can cancel operations which have not yet been submitted.

--- a/io-uring-test/src/tests/register_sync_cancel.rs
+++ b/io-uring-test/src/tests/register_sync_cancel.rs
@@ -82,8 +82,8 @@ pub fn test_register_sync_cancel_unsubmitted<S: squeue::EntryMarker, C: cqueue::
     test: &Test,
 ) -> io::Result<()> {
     require!(
-        test; // We need at least 5.19 for these tests, UringCmd16 is a proxy for that.
-        test.probe.is_supported(opcode::UringCmd16::CODE);
+        test; // We need at least 6.0 to use `IORING_REGISTER_SYNC_CANCEL`. opcode::SendZc is a proxy for that requirement.
+        test.probe.is_supported(opcode::SendZc::CODE);
     );
     // Test that we can cancel operations which have not yet been submitted.
     const USER_DATA: u64 = 42u64;

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -508,19 +508,10 @@ impl<'a> Submitter<'a> {
         timeout: Option<Timespec>,
         builder: CancelBuilder,
     ) -> io::Result<()> {
-        let timespec = match timeout {
-            Some(ref ts) => {
-                // Safety: Timespec is repr(transparent) over __kernel_timespec, so the cast is safe.
-                unsafe { *(ts as *const Timespec as *const sys::__kernel_timespec) }
-            }
-            None => {
-                // Default to an infinite timeout if a timeout is not provided.
-                sys::__kernel_timespec {
-                    tv_sec: -1,
-                    tv_nsec: -1,
-                }
-            }
-        };
+        let timespec = timeout.map(|ts| ts.0).unwrap_or(sys::__kernel_timespec {
+            tv_sec: -1,
+            tv_nsec: -1,
+        });
         let user_data = builder.user_data.unwrap_or(0);
         let fd = builder
             .fd

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -481,8 +481,8 @@ impl<'a> Submitter<'a> {
     /// Performs a synchronous cancellation request, similiar to [AsyncCancel](crate::opcode::AsyncCancel),
     /// except that it completes synchronously.
     ///
-    /// Cancelation can target a specific request, or all requests matching a specific criteria. The
-    /// [MatchOn](types::MatchOn) builder supports describing the match criteria for cancelation.
+    /// Cancellation can target a specific request, or all requests matching a specific criteria. The
+    /// [MatchOn](types::MatchOn) builder supports describing the match criteria for cancellation.
     ///
     /// An optional `timeout` can be provided to specify how long to wait for matched requests to be
     /// canceled. If no timeout is provided, the default is to wait indefinitely.
@@ -494,7 +494,7 @@ impl<'a> Submitter<'a> {
     ///
     /// ### Notes
     ///
-    /// Only requests which have been submitted to the ring will be considered for cancelation. Requests
+    /// Only requests which have been submitted to the ring will be considered for cancellation. Requests
     /// which have been written to the SQ, but not submitted, will not be canceled.
     ///
     /// Available since 6.0.

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -489,8 +489,13 @@ impl<'a> Submitter<'a> {
     ///
     /// ### Errors
     ///
-    /// An error is returned if no requests match the provided match criteria. If a timeout is supplied,
-    /// and the timeout expires before all requests have been canceled, then an error will be returned.
+    /// If no requests are matched, returns:
+    ///
+    /// [io::ErrorKind::NotFound]: `No such file or directory (os error 2)`
+    ///
+    /// If a timeout is supplied, and the timeout elapses prior to all requests being canceled, returns:
+    ///
+    /// [io::ErrorKind::Uncategorized]: `Timer expired (os error 62)`
     ///
     /// ### Notes
     ///

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -501,7 +501,7 @@ impl<'a> Submitter<'a> {
             timespec.tv_sec = timeout.as_secs() as _;
             timespec.tv_nsec = timeout.subsec_nanos() as _;
         }
-        let mut arg = sys::io_uring_sync_cancel_reg {
+        let arg = sys::io_uring_sync_cancel_reg {
             addr: user_data,
             fd: fd,
             flags: flags.bits(),

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -478,10 +478,10 @@ impl<'a> Submitter<'a> {
         .map(drop)
     }
 
-    /// Performs a synchronous cancellation request, similiar to [AsyncCancel](crate::opcode::AsyncCancel),
+    /// Performs a synchronous cancellation request, similar to [AsyncCancel](crate::opcode::AsyncCancel),
     /// except that it completes synchronously.
     ///
-    /// Cancellation can target a specific request, or all requests matching a specific criteria. The
+    /// Cancellation can target a specific request, or all requests matching some criteria. The
     /// [CancelBuilder](types::CancelBuilder) builder supports describing the match criteria for cancellation.
     ///
     /// An optional `timeout` can be provided to specify how long to wait for matched requests to be

--- a/src/types.rs
+++ b/src/types.rs
@@ -555,6 +555,8 @@ impl CancelBuilder {
 
     /// Refine the match criteria to match only requests which contain the
     /// provided `user_data`.
+    ///
+    /// This is mutually exclusive with [CancelBuilder::fd](#method.fd).
     pub fn user_data(mut self, user_data: u64) -> Self {
         // Unset the ANY flag because we want to refine the match criteria to a subset of requests.
         self.flags.set(AsyncCancelFlags::ANY, false);
@@ -569,6 +571,8 @@ impl CancelBuilder {
 
     /// Refine the match criteria to match only requests which reference the
     /// provided `fd`.
+    ///
+    /// This is mutually exclusive with [CancelBuilder::user_data](#method.user_data).
     ///
     /// Note: Support for fixed file descriptors is only available on Linux 6.0+.
     pub fn fd(mut self, fd: impl sealed::UseFixed) -> Self {
@@ -590,8 +594,8 @@ impl CancelBuilder {
 
     /// Match all in-flight requests rather than just the first match.
     ///
-    /// This will cancel all in-flight requests unless [CancelBuilder::user_data] or [CancelBuilder::fd]
-    /// has been called to refine the match criteria.
+    /// This will cancel all in-flight requests unless [CancelBuilder::user_data](#method.user_data) or
+    /// [CancelBuilder::fd](#method.fd) has been called to refine the match criteria.
     pub fn all(mut self) -> Self {
         self.flags.set(AsyncCancelFlags::ALL, true);
         self

--- a/src/types.rs
+++ b/src/types.rs
@@ -91,6 +91,37 @@ bitflags! {
     }
 }
 
+bitflags! {
+    /// Options for [`AsyncCancel`](super::AsyncCancel) and
+    /// [`Submitter::register_sync_cancel`](super::Submitter::register_sync_cancel).
+    pub struct AsyncCancelFlags: u32 {
+        /// Cancel all requests that match the given criteria, rather
+        /// than just canceling the first one found.
+        ///
+        /// Available since 5.19.
+        const ALL = sys::IORING_ASYNC_CANCEL_ALL;
+
+        /// Match based on the file descriptor used in the original
+        /// request rather than the user_data.
+        ///
+        /// Available since 5.19.
+        const FD = sys::IORING_ASYNC_CANCEL_FD;
+
+        /// Match any request in the ring, regardless of user_data or
+        /// file descriptor.  Can be used to cancel any pending
+        /// request in the ring.
+        ///
+        /// Available since 5.19.
+        const ANY = sys::IORING_ASYNC_CANCEL_ANY;
+
+        /// Match based on the fixed file descriptor used in the original
+        /// request rather than the user_data.
+        ///
+        /// Available since 6.0
+        const FD_FIXED = sys::IORING_ASYNC_CANCEL_FD_FIXED;
+    }
+}
+
 /// Wrapper around `open_how` as used in [the `openat2(2)` system
 /// call](https://man7.org/linux/man-pages/man2/openat2.2.html).
 #[derive(Default, Debug, Clone, Copy)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -155,7 +155,7 @@ impl OpenHow {
 
 #[derive(Default, Debug, Clone, Copy)]
 #[repr(transparent)]
-pub struct Timespec(sys::__kernel_timespec);
+pub struct Timespec(pub(crate) sys::__kernel_timespec);
 
 impl Timespec {
     #[inline]

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,7 +4,7 @@ pub(crate) mod sealed {
     use super::{Fd, Fixed};
     use std::os::unix::io::RawFd;
 
-    #[derive(Debug, PartialEq, Eq)]
+    #[derive(Debug)]
     pub enum Target {
         Fd(RawFd),
         Fixed(u32),
@@ -613,14 +613,14 @@ mod tests {
 
         let mut cb = CancelBuilder::fd(Fd(42));
         assert_eq!(cb.flags, AsyncCancelFlags::FD);
-        assert_eq!(cb.fd, Some(Target::Fd(42)));
+        assert!(matches!(cb.fd, Some(Target::Fd(42))));
         assert!(cb.user_data.is_none());
         cb = cb.all();
         assert_eq!(cb.flags, AsyncCancelFlags::FD | AsyncCancelFlags::ALL);
 
         let mut cb = CancelBuilder::fd(Fixed(42));
         assert_eq!(cb.flags, AsyncCancelFlags::FD | AsyncCancelFlags::FD_FIXED);
-        assert_eq!(cb.fd, Some(Target::Fixed(42)));
+        assert!(matches!(cb.fd, Some(Target::Fixed(42))));
         assert!(cb.user_data.is_none());
         cb = cb.all();
         assert_eq!(

--- a/src/types.rs
+++ b/src/types.rs
@@ -507,7 +507,7 @@ impl<'buf> RecvMsgOut<'buf> {
     }
 }
 
-/// [MatchOn] is a builder for constructing match criteria for request cancelation.
+/// [MatchOn] is a builder for constructing match criteria for request cancellation.
 ///
 /// Requests can be canceled by matching on the user_data field and/or the file descriptor.
 ///

--- a/src/types.rs
+++ b/src/types.rs
@@ -628,7 +628,7 @@ mod tests {
         assert_eq!(cb.flags, AsyncCancelFlags::FD);
         assert!(matches!(cb.fd.unwrap(), Target::Fd(1)));
         let cb = CancelBuilder::new().fd(Fixed(1));
-        assert_eq!(cb.flags, AsyncCancelFlags::FD_FIXED);
+        assert_eq!(cb.flags, AsyncCancelFlags::FD_FIXED | AsyncCancelFlags::FD);
         assert!(matches!(cb.fd.unwrap(), Target::Fixed(1)));
 
         // Setting the ALL flag should union with the existing flags.
@@ -639,7 +639,10 @@ mod tests {
         assert_eq!(cb.flags, AsyncCancelFlags::FD | AsyncCancelFlags::ALL);
         assert!(matches!(cb.fd.unwrap(), Target::Fd(1)));
         let cb = CancelBuilder::new().fd(Fixed(1)).all();
-        assert_eq!(cb.flags, AsyncCancelFlags::FD_FIXED | AsyncCancelFlags::ALL);
+        assert_eq!(
+            cb.flags,
+            AsyncCancelFlags::FD_FIXED | AsyncCancelFlags::FD | AsyncCancelFlags::ALL
+        );
         assert!(matches!(cb.fd.unwrap(), Target::Fixed(1)));
 
         // The FD and user_data builders are mutually exclusive.

--- a/src/types.rs
+++ b/src/types.rs
@@ -515,6 +515,8 @@ impl<'buf> RecvMsgOut<'buf> {
 ///
 /// Additionally, [CancelBuilder::all] can be set to match multiple requests.
 ///
+/// ### Examples
+///
 /// ```
 /// use io_uring::types::{CancelBuilder, Fd, Fixed};
 ///


### PR DESCRIPTION
Adds a new Submitter method, register_sync_cancel which can be used to synchronously cancel operations.
Additionally, this adds AsyncCancelFlags used to configure cancellation.

I didn't integrate the `AsyncCancelFlags` with the `opcode::AsyncCancel` in this PR, mostly because I haven't needed it but I can either do that in this PR or a follow-up PR. 