### PR TITLE
tests/net: relax FD assertion for socket opcode check

### DIFF
--- a/io-uring-test/src/tests/net.rs
+++ b/io-uring-test/src/tests/net.rs
@@ -1244,7 +1244,8 @@ pub fn test_socket<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 42);
-    assert_eq!(cqes[0].result(), plain_fd + 1);
+    assert!(cqes[0].result() >= 0);
+    assert!(cqes[0].result() != plain_fd);
     assert_eq!(cqes[0].flags(), 0);
 
     // Close both sockets, to avoid leaking FDs.


### PR DESCRIPTION
This tweaks the socket opcode test in order to relax FD assertions. Checking for exact FD number can race when other threads are also opening/closing FDs, so just perform non-exact sanity checks instead.

Closes: https://github.com/tokio-rs/io-uring/issues/208