### PR TITLE
Added option to use SendZc for connectionless streams.

### DIFF
--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -132,6 +132,7 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     tests::net::test_shutdown(&mut ring, &test)?;
     tests::net::test_socket(&mut ring, &test)?;
     tests::net::test_udp_recvmsg_multishot(&mut ring, &test)?;
+    tests::net::test_udp_sendzc_with_dest(&mut ring, &test)?;
 
     // queue
     tests::poll::test_eventfd_poll(&mut ring, &test)?;

--- a/io-uring-test/src/tests/net.rs
+++ b/io-uring-test/src/tests/net.rs
@@ -1,12 +1,12 @@
 use crate::utils;
 use crate::Test;
+use io_uring::types::Fd;
 use io_uring::{cqueue, opcode, squeue, types, IoUring};
 use once_cell::sync::OnceCell;
 use std::net::{TcpListener, TcpStream};
 use std::os::fd::FromRawFd;
 use std::os::unix::io::AsRawFd;
 use std::{io, mem};
-use io_uring::types::Fd;
 
 static TCP_LISTENER: OnceCell<TcpListener> = OnceCell::new();
 
@@ -1471,9 +1471,9 @@ pub fn test_udp_sendzc_with_dest<S: squeue::EntryMarker, C: cqueue::EntryMarker>
     }
 
     let recvmsg_e = opcode::RecvMulti::new(Fd(server_socket.as_raw_fd()), BUF_GROUP)
-            .build()
-            .user_data(3)
-            .into();
+        .build()
+        .user_data(3)
+        .into();
     unsafe { ring.submission().push(&recvmsg_e)? };
     ring.submitter().submit()?;
 
@@ -1499,8 +1499,7 @@ pub fn test_udp_sendzc_with_dest<S: squeue::EntryMarker, C: cqueue::EntryMarker>
         .into();
 
     unsafe {
-        ring.submission()
-            .push_multiple(&[entry1, entry2])?;
+        ring.submission().push_multiple(&[entry1, entry2])?;
     }
 
     // Check the completion events for the two UDP messages, plus a trailing

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1646,6 +1646,9 @@ opcode!(
 opcode!(
     /// Send a zerocopy message on a socket, equivalent to `send(2)`.
     ///
+    /// When `dest_addr` is non-zero it points to the address of the target with `dest_addr_len`
+    /// specifying its size, turning the request into a `sendto(2)`
+    ///
     /// A fixed (pre-mapped) buffer can optionally be used from pre-mapped buffers that have been
     /// previously registered with [`Submitter::register_buffers`](crate::Submitter::register_buffers).
     pub struct SendZc {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1660,6 +1660,8 @@ opcode!(
         /// previously registered buffer. The buffer need not be aligned with the start of the
         /// registered buffer.
         buf_index: Option<u16> = None,
+        dest_addr: *const libc::sockaddr = core::ptr::null(),
+        dest_addr_len: libc::socklen_t = 0,
         flags: i32 = 0,
         zc_flags: u16 = 0,
     }
@@ -1667,7 +1669,7 @@ opcode!(
     pub const CODE = sys::IORING_OP_SEND_ZC;
 
     pub fn build(self) -> Entry {
-        let SendZc { fd, buf, len, buf_index, flags, zc_flags } = self;
+        let SendZc { fd, buf, len, buf_index, dest_addr, dest_addr_len, flags, zc_flags } = self;
 
         let mut sqe = sqe_zeroed();
         sqe.opcode = Self::CODE;
@@ -1680,6 +1682,8 @@ opcode!(
             sqe.__bindgen_anon_4.buf_index = buf_index;
             sqe.ioprio |= sys::IORING_RECVSEND_FIXED_BUF as u16;
         }
+        sqe.__bindgen_anon_1.addr2 = dest_addr as _;
+        sqe.__bindgen_anon_5.__bindgen_anon_1.addr_len = dest_addr_len as _;
         Entry(sqe)
     }
 );


### PR DESCRIPTION
With this changes we can set destination address. It is usefull when working with connectionless UDP, like `.send_to()`.
```
let std = SocketAddrV6::new(Ipv6Addr::new(1, 2, 3, 4, 5, 6, 7, 8), 9876, 11, 12);
let dest_addr = SockAddr::from(std);
let sendzc = opcode::SendZc::new(Fd(self.as_raw_fd()), buf.as_ptr(), buf.len() as _)
    .dest_addr(dest_addr.as_ptr())
    .dest_addr_len(dest_addr.len())
    .build()
    .user_data(1);
```