### PR TITLE
feat: create async cancel op with cancel builder

### DIFF
--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -79,6 +79,14 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     tests::register_sync_cancel::test_register_sync_cancel(&mut ring, &test)?;
     tests::register_sync_cancel::test_register_sync_cancel_unsubmitted(&mut ring, &test)?;
     tests::register_sync_cancel::test_register_sync_cancel_any(&mut ring, &test)?;
+
+    // async cancellation
+    tests::cancel::test_async_cancel_user_data(&mut ring, &test)?;
+    tests::cancel::test_async_cancel_user_data_all(&mut ring, &test)?;
+    tests::cancel::test_async_cancel_any(&mut ring, &test)?;
+    tests::cancel::test_async_cancel_fd(&mut ring, &test)?;
+    tests::cancel::test_async_cancel_fd_all(&mut ring, &test)?;
+
     // fs
     tests::fs::test_file_write_read(&mut ring, &test)?;
     tests::fs::test_file_writev_readv(&mut ring, &test)?;

--- a/io-uring-test/src/tests/cancel.rs
+++ b/io-uring-test/src/tests/cancel.rs
@@ -1,0 +1,267 @@
+use crate::Test;
+use io_uring::types::CancelBuilder;
+use io_uring::{cqueue, opcode, squeue, types, IoUring};
+use std::fs::File;
+use std::os::fd::FromRawFd;
+use std::os::unix::io::AsRawFd;
+
+// Cancels one request matching the user data.
+pub fn test_async_cancel_user_data<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
+    require!(
+        test;
+        test.probe.is_supported(opcode::Timeout::CODE);
+        test.probe.is_supported(opcode::AsyncCancel2::CODE);
+    );
+
+    println!("test async_cancel_user_data");
+
+    let ts = types::Timespec::new().sec(1);
+    let timeout_e = opcode::Timeout::new(&ts).build();
+
+    // Cancel the timeout matching user data
+    let builder = CancelBuilder::user_data(2003);
+    let cancel_e = opcode::AsyncCancel2::new(builder).build();
+
+    let entries = [
+        timeout_e.user_data(2003).into(),
+        cancel_e.user_data(2004).into(),
+    ];
+    for sqe in &entries {
+        unsafe {
+            ring.submission().push(sqe).expect("queue is full");
+        }
+    }
+
+    // Wait for both timeout and the cancel request.
+    ring.submit_and_wait(entries.len())?;
+
+    let mut cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
+    cqes.sort_unstable_by_key(cqueue::Entry::user_data);
+
+    assert_eq!(cqes.len(), entries.len());
+
+    assert_eq!(cqes[0].user_data(), 2003);
+    assert_eq!(cqes[1].user_data(), 2004);
+
+    assert_eq!(cqes[0].result(), -libc::ECANCELED); // -ECANCELED
+    assert_eq!(cqes[1].result(), 0); // the number of requests cancelled
+
+    Ok(())
+}
+
+// Cancels one request matching the user data.
+pub fn test_async_cancel_user_data_all<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
+    require!(
+        test;
+        test.probe.is_supported(opcode::Timeout::CODE);
+        test.probe.is_supported(opcode::AsyncCancel2::CODE);
+        test.probe.is_supported(opcode::Socket::CODE); // Check if Kernel >= 5.19
+    );
+
+    println!("test async_cancel_user_data_all");
+
+    let ts = types::Timespec::new().sec(1);
+    let timeout_e = opcode::Timeout::new(&ts).build();
+
+    // Cancel all timeouts matching user data
+    let builder = CancelBuilder::user_data(2003).all();
+    let cancel_e = opcode::AsyncCancel2::new(builder).build();
+
+    let entries = [
+        timeout_e.clone().user_data(2003).into(),
+        timeout_e.user_data(2003).into(),
+        cancel_e.user_data(2004).into(),
+    ];
+    for sqe in &entries {
+        unsafe {
+            ring.submission().push(sqe).expect("queue is full");
+        }
+    }
+
+    // Wait for both timeouts and the cancel request.
+    ring.submit_and_wait(entries.len())?;
+
+    let mut cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
+    cqes.sort_unstable_by_key(cqueue::Entry::user_data);
+
+    assert_eq!(cqes.len(), entries.len());
+
+    assert_eq!(cqes[0].user_data(), 2003);
+    assert_eq!(cqes[1].user_data(), 2003);
+    assert_eq!(cqes[2].user_data(), 2004);
+
+    assert_eq!(cqes[0].result(), -libc::ECANCELED); // -ECANCELED
+    assert_eq!(cqes[1].result(), -libc::ECANCELED); // -ECANCELED
+    assert_eq!(cqes[2].result(), 2); // the number of requests cancelled
+
+    Ok(())
+}
+
+// Cancels any requests.
+pub fn test_async_cancel_any<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
+    require!(
+        test;
+        test.probe.is_supported(opcode::Timeout::CODE);
+        test.probe.is_supported(opcode::AsyncCancel2::CODE);
+        test.probe.is_supported(opcode::Socket::CODE); // Check if Kernel >= 5.19
+    );
+
+    println!("test async_cancel_any");
+
+    let ts = types::Timespec::new().sec(1);
+    let timeout_e = opcode::Timeout::new(&ts).build();
+
+    // Cancel any pending requests
+    let builder = CancelBuilder::any();
+    let cancel_e = opcode::AsyncCancel2::new(builder).build();
+
+    let entries = [
+        timeout_e.clone().user_data(2003).into(),
+        timeout_e.user_data(2004).into(),
+        cancel_e.user_data(2005).into(),
+    ];
+    for sqe in &entries {
+        unsafe {
+            ring.submission().push(sqe).expect("queue is full");
+        }
+    }
+
+    // Wait for both timeouts and the cancel request.
+    ring.submit_and_wait(entries.len())?;
+
+    let mut cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
+    cqes.sort_unstable_by_key(cqueue::Entry::user_data);
+
+    assert_eq!(cqes.len(), entries.len());
+
+    assert_eq!(cqes[0].user_data(), 2003);
+    assert_eq!(cqes[1].user_data(), 2004);
+    assert_eq!(cqes[2].user_data(), 2005);
+
+    assert_eq!(cqes[0].result(), -libc::ECANCELED); // -ECANCELED
+    assert_eq!(cqes[1].result(), -libc::ECANCELED);
+    assert_eq!(cqes[2].result(), 2); // the number of requests cancelled
+
+    Ok(())
+}
+
+pub fn test_async_cancel_fd<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
+    require!(
+        test;
+        test.probe.is_supported(opcode::PollAdd::CODE);
+        test.probe.is_supported(opcode::AsyncCancel2::CODE);
+        test.probe.is_supported(opcode::Socket::CODE); // Check if Kernel >= 5.19
+    );
+
+    println!("test async_cancel_fd");
+
+    let _fd = create_dummy_fd()?;
+    let fd = types::Fd(_fd.as_raw_fd());
+    let poll_e = opcode::PollAdd::new(fd, libc::POLLIN as _).build();
+
+    // Cancel one poll request matching FD
+    let builder = CancelBuilder::fd(fd);
+    let cancel_e = opcode::AsyncCancel2::new(builder).build();
+
+    let entries = [
+        poll_e.user_data(2003).into(),
+        cancel_e.user_data(2004).into(),
+    ];
+    for sqe in &entries {
+        unsafe {
+            ring.submission().push(sqe).expect("queue is full");
+        }
+    }
+
+    // Wait for 2 requests: canceled poll and the cancel request itself.
+    ring.submit_and_wait(entries.len())?;
+
+    let mut cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
+    cqes.sort_unstable_by_key(cqueue::Entry::user_data);
+
+    assert_eq!(cqes.len(), entries.len());
+
+    assert_eq!(cqes[0].user_data(), 2003);
+    assert_eq!(cqes[1].user_data(), 2004);
+
+    assert_eq!(cqes[0].result(), -libc::ECANCELED); // -ECANCELED
+    assert_eq!(cqes[1].result(), 0);
+
+    Ok(())
+}
+
+// Cancels all pending requests with the given FD.
+pub fn test_async_cancel_fd_all<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
+    require!(
+        test;
+        test.probe.is_supported(opcode::PollAdd::CODE);
+        test.probe.is_supported(opcode::AsyncCancel2::CODE);
+        test.probe.is_supported(opcode::Socket::CODE); // Check if Kernel >= 5.19
+    );
+
+    println!("test async_cancel_fd_all");
+
+    let _fd = create_dummy_fd()?;
+    let fd = types::Fd(_fd.as_raw_fd());
+    let poll_e = opcode::PollAdd::new(fd, libc::POLLIN as _).build();
+
+    // Cancel all requests matching FD
+    let builder = CancelBuilder::fd(fd).all();
+    let cancel_e = opcode::AsyncCancel2::new(builder).build();
+
+    let entries = [
+        poll_e.clone().user_data(2003).into(),
+        poll_e.user_data(2004).into(),
+        cancel_e.user_data(2005).into(),
+    ];
+    for sqe in &entries {
+        unsafe {
+            ring.submission().push(sqe).expect("queue is full");
+        }
+    }
+
+    // Wait for both polls and the cancel request.
+    ring.submit_and_wait(entries.len())?;
+
+    let mut cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
+    cqes.sort_unstable_by_key(cqueue::Entry::user_data);
+
+    assert_eq!(cqes.len(), entries.len());
+
+    assert_eq!(cqes[0].user_data(), 2003);
+    assert_eq!(cqes[1].user_data(), 2004);
+    assert_eq!(cqes[2].user_data(), 2005);
+
+    assert_eq!(cqes[0].result(), -libc::ECANCELED); // -ECANCELED
+    assert_eq!(cqes[1].result(), -libc::ECANCELED);
+    assert_eq!(cqes[2].result(), 2); // the number of requests cancelled
+
+    Ok(())
+}
+
+fn create_dummy_fd() -> anyhow::Result<File> {
+    unsafe {
+        let fd = libc::eventfd(0, libc::EFD_CLOEXEC);
+
+        if fd == -1 {
+            return Err(std::io::Error::last_os_error().into());
+        }
+
+        Ok(File::from_raw_fd(fd))
+    }
+}

--- a/io-uring-test/src/tests/mod.rs
+++ b/io-uring-test/src/tests/mod.rs
@@ -1,3 +1,4 @@
+pub mod cancel;
 pub mod fs;
 pub mod net;
 pub mod poll;

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1464,6 +1464,29 @@ opcode! {
 // === 5.19 ===
 
 opcode! {
+    /// Attempt to cancel an already issued request, receiving a cancellation
+    /// builder, which allows for the new cancel criterias introduced since
+    /// 5.19.
+    pub struct AsyncCancel2 {
+        builder: { types::CancelBuilder }
+        ;;
+    }
+
+    pub const CODE = sys::IORING_OP_ASYNC_CANCEL;
+
+    pub fn build(self) -> Entry {
+        let AsyncCancel2 { builder } = self;
+
+        let mut sqe = sqe_zeroed();
+        sqe.opcode = Self::CODE;
+        sqe.fd = builder.to_fd();
+        sqe.__bindgen_anon_2.addr = builder.user_data.unwrap_or(0);
+        sqe.__bindgen_anon_3.cancel_flags = builder.flags.bits();
+        Entry(sqe)
+    }
+}
+
+opcode! {
     /// A file/device-specific 16-byte command, akin (but not equivalent) to `ioctl(2)`.
     pub struct UringCmd16 {
         fd: { impl sealed::UseFixed },

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -506,14 +506,8 @@ impl<'a> Submitter<'a> {
             tv_nsec: -1,
         });
         let user_data = builder.user_data.unwrap_or(0);
-        let fd = builder
-            .fd
-            .map(|target| match target {
-                types::sealed::Target::Fd(fd) => fd,
-                types::sealed::Target::Fixed(idx) => idx as i32,
-            })
-            .unwrap_or(-1);
         let flags = builder.flags.bits();
+        let fd = builder.to_fd();
 
         let arg = sys::io_uring_sync_cancel_reg {
             addr: user_data,


### PR DESCRIPTION
Hi! [Kernel 5.19 introduced new flags](https://man7.org/linux/man-pages/man3/io_uring_prep_cancel.3.html) to the async cancel operation (that would
later also be used by `register_sync_cancel` in 6.0).

I hereby propose adding the ability to set up such flags within the existing `AsyncCancel`
operation, or via a new one.

I dislike having this not-so-obvious `builder` function on `AsyncCancel` but I also don't like
having a separate opcode solely to support the builder. Apart from the "hidden" builder feature,
using the same struct also mixes the new 5.19/6.0 (fixed FD) features.

Another option is to leave the flags to be manually set by the app, but why the extra hassle
if `CancelBuilder` is so handy? This was my first approach and the result didn't convince me.