### PR TITLE
Add flags to async cancel

### DIFF
--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -648,19 +648,20 @@ opcode! {
     pub struct AsyncCancel {
         user_data: { u64 }
         ;;
-
+        flags : types::AsyncCancelFlags = types::AsyncCancelFlags::empty()
         // TODO flags
     }
 
     pub const CODE = sys::IORING_OP_ASYNC_CANCEL;
 
     pub fn build(self) -> Entry {
-        let AsyncCancel { user_data } = self;
+        let AsyncCancel { user_data, flags } = self;
 
         let mut sqe = sqe_zeroed();
         sqe.opcode = Self::CODE;
         sqe.fd = -1;
         sqe.__bindgen_anon_2.addr = user_data;
+        sqe.__bindgen_anon_3.cancel_flags = flags.bits();
         Entry(sqe)
     }
 }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -649,7 +649,6 @@ opcode! {
         user_data: { u64 }
         ;;
         flags : types::AsyncCancelFlags = types::AsyncCancelFlags::empty()
-        // TODO flags
     }
 
     pub const CODE = sys::IORING_OP_ASYNC_CANCEL;

--- a/src/types.rs
+++ b/src/types.rs
@@ -110,7 +110,7 @@ bitflags! {
 bitflags! {
     /// Options for [`AsyncCancel`](super::AsyncCancel) and
     /// [`Submitter::register_sync_cancel`](super::Submitter::register_sync_cancel).
-    pub(crate) struct AsyncCancelFlags: u32 {
+    pub struct AsyncCancelFlags: u32 {
         /// Cancel all requests that match the given criteria, rather
         /// than just canceling the first one found.
         ///


### PR DESCRIPTION
Adds the ability to set the flags to async cancel. Also makes public the existing `AsyncCancelFlags`