### PR TITLE
bug: fix overflow in `io-uring-test::register_buf_ring::InnerBufRing::buf_ring_push`

### DIFF
--- a/io-uring-test/src/tests/register_buf_ring.rs
+++ b/io-uring-test/src/tests/register_buf_ring.rs
@@ -305,7 +305,7 @@ impl InnerBufRing {
         // for computing the ring entry, not to the tail value itself.
 
         let old_tail = self.local_tail.get();
-        self.local_tail.set(old_tail + 1);
+        self.local_tail.set(old_tail.wrapping_add(1));
         let ring_idx = old_tail & self.mask();
 
         let entries = self.ring_start.as_ptr_mut() as *mut BufRingEntry;

--- a/io-uring-test/src/tests/register_buf_ring.rs
+++ b/io-uring-test/src/tests/register_buf_ring.rs
@@ -667,9 +667,9 @@ fn buf_ring_play<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     std::mem::drop(buf3);
     std::mem::drop(buf4);
 
-    // Now we loop u16::MAX+1 times to ensure proper behavior when the tail
+    // Now we loop u16::MAX times to ensure proper behavior when the tail
     // overflows the bounds of a u16.
-    for _ in 0..(u16::MAX as usize + 1) {
+    for _ in 0..=u16::MAX {
         let _ = buf_ring_read(ring, &buf_ring, fd, len)?;
     }
 

--- a/io-uring-test/src/tests/register_buf_ring.rs
+++ b/io-uring-test/src/tests/register_buf_ring.rs
@@ -664,6 +664,15 @@ fn buf_ring_play<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     normal_check(&buf3, 1); // bid 1 should come back first.
     normal_check(&buf4, 0); // bid 0 should come back second.
 
+    std::mem::drop(buf3);
+    std::mem::drop(buf4);
+
+    // Now we loop u16::MAX+1 times to ensure proper behavior when the tail
+    // overflows the bounds of a u16.
+    for _ in 0..(u16::MAX as usize + 1) {
+        let _ = buf_ring_read(ring, &buf_ring, fd, len)?;
+    }
+
     // Be nice. In this test, the buf_ring is manually unregistered.
     // There is no need to ensure the buffers have been dropped first.
     buf_ring.rc.unregister(ring)?;


### PR DESCRIPTION
With only c95a383de432dea6f73298dc8a998711d24cdc8f applied, running in debug mode results in a panic as the `old_tail + 1` logic will overflow when we've pushed more than `u16::MAX` times.

```
thread 'main' panicked at io-uring-test/src/tests/register_buf_ring.rs:308:24:
attempt to add with overflow
```

With 80b8982f290e287690b8c9e5d00668797a187557 applied, we properly wrap when we reach the boundary of `u16`.