### PR TITLE
Add support for IORING_REGISTER_IOWQ_AFF

### DIFF
--- a/src/submit.rs
+++ b/src/submit.rs
@@ -396,6 +396,45 @@ impl<'a> Submitter<'a> {
         .map(drop)
     }
 
+    /// Tell io_uring on what CPUs the async workers can run. By default, async workers
+    /// created by io_uring will inherit the CPU mask of its parent. This is usually
+    /// all the CPUs in the system, unless the parent is being run with a limited set.
+    pub fn register_iowq_aff(&self, cores: &[u32]) -> io::Result<()> {
+        let mut cpu_set: libc::cpu_set_t = unsafe { mem::zeroed() };
+        let max_core = (mem::size_of::<libc::cpu_set_t>() * 8) as u32;
+
+        for &core in cores {
+            if core >= max_core {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("Could not set {} in cpu_set", core),
+                ));
+            }
+            unsafe {
+                libc::CPU_SET(core as usize, &mut cpu_set);
+            }
+        }
+
+        execute(
+            self.fd.as_raw_fd(),
+            sys::IORING_REGISTER_IOWQ_AFF,
+            &cpu_set as *const _ as *const libc::c_void,
+            mem::size_of::<libc::cpu_set_t>() as u32,
+        )
+        .map(drop)
+    }
+
+    /// Undoes a CPU mask previously set with register_iowq_aff
+    pub fn unregister_iowq_aff(&self) -> io::Result<()> {
+        execute(
+            self.fd.as_raw_fd(),
+            sys::IORING_UNREGISTER_IOWQ_AFF,
+            ptr::null(),
+            0,
+        )
+        .map(drop)
+    }
+
     /// Get and/or set the limit for number of io_uring worker threads per NUMA
     /// node. `max[0]` holds the limit for bounded workers, which process I/O
     /// operations expected to be bound in time, that is I/O on regular files or


### PR DESCRIPTION
Hi,

I found that methods to specify cores for async workers are missing in this library.

Manpage: https://manpages.debian.org/unstable/liburing-dev/io_uring_register.2.en.html#IORING_REGISTER_IOWQ_AFF
Usage example in liburing: https://github.com/axboe/liburing/blob/cb00b6d807efaaaa5455223bf28a73fa216b2d24/test/wq-aff.c#L106

I decided to pull the libc::cpu_set_t related code into `register_iowq_aff`. If you think this is a bad idea, I'm happy to adapt the pull-request.