### PR TITLE
pass `cqe->flags` with `MsgRingData`

### DIFF
--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1454,8 +1454,8 @@ opcode! {
         sqe.__bindgen_anon_1.off = user_data;
         sqe.__bindgen_anon_3.msg_ring_flags = opcode_flags;
         if let Some(_flags) = user_flags {
-            // TODO(lucab): add IORING_MSG_RING_FLAGS_PASS support (in v6.3):
-            // https://lore.kernel.org/all/20230103160507.617416-1-leitao@debian.org/t/#u
+            sqe.__bindgen_anon_5.file_index = _flags;
+            unsafe {sqe.__bindgen_anon_3.msg_ring_flags |= sys::IORING_MSG_RING_FLAGS_PASS};
         }
         Entry(sqe)
     }


### PR DESCRIPTION
This PR allows to pass `cqe->flags` with `MsgRingData`.

based on: [axboe/liburing](https://github.com/axboe/liburing/blob/7524a6adf4d6720a47bfa617b5cb2fd8d57f16d2/src/include/liburing.h#L1032).