### PR TITLE
Implement `AsFd` for all entry sizes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -612,7 +612,7 @@ impl<S: squeue::EntryMarker, C: cqueue::EntryMarker> AsRawFd for IoUring<S, C> {
 }
 
 #[cfg(feature = "io_safety")]
-impl AsFd for IoUring {
+impl<S: squeue::EntryMarker, C: cqueue::EntryMarker> AsFd for IoUring<S, C> {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.fd.as_fd()
     }


### PR DESCRIPTION
It seems to be a merge error of two concurrent PRs #133 and #134, which results in `AsFd` only implemented specifically on `IoUring<Entry, Entry>` rather than generically. This PR generalized that impl, also to align with `AsRawFd` impl.