### PR TITLE
Fix broken RecvMsgOut parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,6 +361,7 @@ dependencies = [
  "io-uring",
  "libc",
  "once_cell",
+ "semver",
  "socket2",
  "tempfile",
 ]
@@ -674,6 +675,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"

--- a/io-uring-test/Cargo.toml
+++ b/io-uring-test/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1"
 tempfile = "3"
 once_cell = "1"
 socket2 = "0.5"
+semver = "1.0.21"
 
 [features]
 direct-syscall = [ "io-uring/direct-syscall" ]

--- a/io-uring-test/src/utils.rs
+++ b/io-uring-test/src/utils.rs
@@ -6,9 +6,10 @@ macro_rules! require {
         $test:expr;
         $( $cond:expr ; )*
     ) => {
+        let test = $test;
         let mut cond = true;
 
-        if let Some(target) = $test.target.as_ref() {
+        if let Some(target) = test.target.as_ref() {
             cond &= function_name!().contains(target);
         }
 
@@ -20,7 +21,7 @@ macro_rules! require {
             return Ok(());
         }
 
-        $test.count.set($test.count.get() + 1);
+        test.count.set(test.count.get() + 1);
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -508,6 +508,16 @@ impl<'buf> RecvMsgOut<'buf> {
         self.payload_data
     }
 
+    /// Return the length of the incoming `payload` data.
+    ///
+    /// This may be larger than the size of the content returned by
+    /// `payload_data()`, if the kernel could not fit all the incoming
+    /// data in the provided buffer size. In that case, payload data in
+    /// the result buffer gets truncated.
+    pub fn incoming_payload_len(&self) -> u32 {
+        self.header.payloadlen
+    }
+
     /// Message flags, with the same semantics as `msghdr.msg_flags`.
     pub fn flags(&self) -> u32 {
         self.header.flags


### PR DESCRIPTION
The current parsing doesn't actually let the buffer ever be truncated and instead errors out immediately. This PR fixes it to only ever out when the buffer is smaller than the header. This implementation matches liburing's validation: https://github.com/axboe/liburing/blob/c44319a6bfb9953b430325227a94136690c19c33/src/include/liburing.h#L831-L834