### PR TITLE
feat: allow uring builder to customize flags/features

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,12 +407,12 @@ impl<S: squeue::EntryMarker, C: cqueue::EntryMarker> Builder<S, C> {
         self
     }
 
-    pub fn with_flags(&mut self, flags : __u32) -> &mut Self {
+    pub fn with_flags(&mut self, flags: __u32) -> &mut Self {
         self.params.flags |= flags;
         self
     }
 
-    pub fn with_features(&mut self, features : __u32) -> &mut Self{
+    pub fn with_features(&mut self, features: __u32) -> &mut Self{
         self.params.features |= features;
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub use register::Probe;
 pub use squeue::SubmissionQueue;
 pub use submit::Submitter;
 use util::{Mmap, OwnedFd};
+use crate::sys::__u32;
 
 /// IoUring instance
 ///
@@ -403,6 +404,16 @@ impl<S: squeue::EntryMarker, C: cqueue::EntryMarker> Builder<S, C> {
     /// userspace tasks can call [`Submitter::enter`] and higher level APIs. Available since 6.0.
     pub fn setup_single_issuer(&mut self) -> &mut Self {
         self.params.flags |= sys::IORING_SETUP_SINGLE_ISSUER;
+        self
+    }
+
+    pub fn with_flags(&mut self, flags : __u32) -> &mut Self {
+        self.params.flags |= flags;
+        self
+    }
+
+    pub fn with_features(&mut self, features : __u32) -> &mut Self{
+        self.params.features |= features;
         self
     }
 


### PR DESCRIPTION
Currently, users cannot directly customize the flags and params of the uring builder, and with the rapid iteration of io_uring in the kernel, many new features will not be compatible with existing applications. So we need to provide more flexibility in the uring builder to allow customization of flags and params.