### PR TITLE
Update documentation for `ReadFixed` and `WriteFixed`

### DIFF
--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -230,23 +230,11 @@ opcode! {
     /// Read from a file into a fixed buffer that has been previously registered with
     /// [`Submitter::register_buffers`](crate::Submitter::register_buffers).
     ///
-    /// The operation designated by this `opcode` will read data from a file at a specific offset
-    /// into a fixed buffer that has been registered into the `io-uring` instance via
-    /// [`Submitter::register_buffers`](crate::Submitter::register_buffers).
-    ///
-    /// The caller must ensure that the `buf_index` argument indexes into the list of buffers that
-    /// have been registered and that the buffer the index refers to has a base pointer of `buf` and
-    /// a length of `len`.
-    ///
     /// The return values match those documented in the `preadv2(2)` man pages.
     ///
     /// See the man pages for `io_uring_prep_read_fixed(3)` for more information.
     #[derive(Debug)]
     pub struct ReadFixed {
-        /// This operation is only valid if `buf_index` is an index into an array of previously
-        /// registered fixed buffers, and the `buf` and `len` arguments fall within the region
-        /// specified by `buf_index`. Note that `buf` does not need to be aligned with the start of
-        /// the registered buffer.
         fd: { impl sealed::UseFixed },
         buf: { *mut u8 },
         len: { u32 },
@@ -287,23 +275,11 @@ opcode! {
     /// Write to a file from a fixed buffer that have been previously registered with
     /// [`Submitter::register_buffers`](crate::Submitter::register_buffers).
     ///
-    /// The operation designated by this `opcode` will write data into a file at a specific offset
-    /// from a fixed buffer that has been registered into the `io-uring` instance via
-    /// [`Submitter::register_buffers`](crate::Submitter::register_buffers).
-    ///
-    /// The caller must ensure that the `buf_index` argument indexes into the list of buffers that
-    /// have been registered and that the buffer the index refers to has a base pointer of `buf` and
-    /// a length of `len`.
-    ///
     /// The return values match those documented in the `pwritev2(2)` man pages.
     ///
     /// See the man pages for `io_uring_prep_write_fixed(3)` for more information.
     #[derive(Debug)]
     pub struct WriteFixed {
-        /// This operation is only valid if `buf_index` is an index into an array of previously
-        /// registered fixed buffers, and the `buf` and `len` arguments fall within the region
-        /// specified by `buf_index`. Note that `buf` does not need to be aligned with the start of
-        /// the registered buffer.
         fd: { impl sealed::UseFixed },
         buf: { *const u8 },
         len: { u32 },
@@ -313,7 +289,7 @@ opcode! {
         /// The offset of the file to write to.
         offset: u64 = 0,
         /// Specified for write operations, contains a bitwise OR of per-I/O flags, as described in
-        /// the `preadv2(2)` man page.
+        /// the `pwritev2(2)` man page.
         rw_flags: types::RwFlags = 0
     }
 

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -231,8 +231,6 @@ opcode! {
     /// [`Submitter::register_buffers`](crate::Submitter::register_buffers).
     ///
     /// The return values match those documented in the `preadv2(2)` man pages.
-    ///
-    /// See the man pages for `io_uring_prep_read_fixed(3)` for more information.
     #[derive(Debug)]
     pub struct ReadFixed {
         fd: { impl sealed::UseFixed },
@@ -276,8 +274,6 @@ opcode! {
     /// [`Submitter::register_buffers`](crate::Submitter::register_buffers).
     ///
     /// The return values match those documented in the `pwritev2(2)` man pages.
-    ///
-    /// See the man pages for `io_uring_prep_write_fixed(3)` for more information.
     #[derive(Debug)]
     pub struct WriteFixed {
         fd: { impl sealed::UseFixed },

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -227,23 +227,36 @@ opcode! {
 }
 
 opcode! {
-    /// Read from pre-mapped buffers that have been previously registered with
+    /// Read from a file into a fixed buffer that has been previously registered with
     /// [`Submitter::register_buffers`](crate::Submitter::register_buffers).
     ///
+    /// The operation designated by this `opcode` will read data from a file at a specific offset
+    /// into a fixed buffer that has been registered into the `io-uring` instance via
+    /// [`Submitter::register_buffers`](crate::Submitter::register_buffers).
+    ///
+    /// The caller must ensure that the `buf_index` argument indexes into the list of buffers that
+    /// have been registered and that the buffer the index refers to has a base pointer of `buf` and
+    /// a length of `len`.
+    ///
     /// The return values match those documented in the `preadv2(2)` man pages.
+    ///
+    /// See the man pages for `io_uring_prep_read_fixed(3)` for more information.
     #[derive(Debug)]
     pub struct ReadFixed {
-        /// The `buf_index` is an index into an array of fixed buffers,
-        /// and is only valid if fixed buffers were registered.
+        /// This operation is only valid if `buf_index` is an index into an array of previously
+        /// registered fixed buffers, and the `buf` and `len` arguments fall within the region
+        /// specified by `buf_index`. Note that `buf` does not need to be aligned with the start of
+        /// the registered buffer.
         fd: { impl sealed::UseFixed },
         buf: { *mut u8 },
         len: { u32 },
         buf_index: { u16 },
         ;;
-        offset: u64 = 0,
         ioprio: u16 = 0,
-        /// specified for read operations, contains a bitwise OR of per-I/O flags,
-        /// as described in the `preadv2(2)` man page.
+        /// The offset of the file to read from.
+        offset: u64 = 0,
+        /// Specified for read operations, contains a bitwise OR of per-I/O flags, as described in
+        /// the `preadv2(2)` man page.
         rw_flags: types::RwFlags = 0
     }
 
@@ -271,23 +284,36 @@ opcode! {
 }
 
 opcode! {
-    /// Write to pre-mapped buffers that have been previously registered with
+    /// Write to a file from a fixed buffer that have been previously registered with
     /// [`Submitter::register_buffers`](crate::Submitter::register_buffers).
     ///
+    /// The operation designated by this `opcode` will write data into a file at a specific offset
+    /// from a fixed buffer that has been registered into the `io-uring` instance via
+    /// [`Submitter::register_buffers`](crate::Submitter::register_buffers).
+    ///
+    /// The caller must ensure that the `buf_index` argument indexes into the list of buffers that
+    /// have been registered and that the buffer the index refers to has a base pointer of `buf` and
+    /// a length of `len`.
+    ///
     /// The return values match those documented in the `pwritev2(2)` man pages.
+    ///
+    /// See the man pages for `io_uring_prep_write_fixed(3)` for more information.
     #[derive(Debug)]
     pub struct WriteFixed {
-        /// The `buf_index` is an index into an array of fixed buffers,
-        /// and is only valid if fixed buffers were registered.
+        /// This operation is only valid if `buf_index` is an index into an array of previously
+        /// registered fixed buffers, and the `buf` and `len` arguments fall within the region
+        /// specified by `buf_index`. Note that `buf` does not need to be aligned with the start of
+        /// the registered buffer.
         fd: { impl sealed::UseFixed },
         buf: { *const u8 },
         len: { u32 },
         buf_index: { u16 },
         ;;
         ioprio: u16 = 0,
+        /// The offset of the file to write to.
         offset: u64 = 0,
-        /// specified for write operations, contains a bitwise OR of per-I/O flags,
-        /// as described in the `preadv2(2)` man page.
+        /// Specified for write operations, contains a bitwise OR of per-I/O flags, as described in
+        /// the `preadv2(2)` man page.
         rw_flags: types::RwFlags = 0
     }
 


### PR DESCRIPTION
Adds some detail to the `ReadFixed` and `WriteFixed` opcodes (referred to in #275).

There is one small problem with this: I've documented the expected behavior according to the man pages, but I have actually yet to see these opcodes work in Rust. Are there any tests that check if these opcodes are correct? (My personal testing seems to not work, but it is very possible I've just set it up wrong since I haven't looked too deeply into it...)

Also, I am not completely sure why the `buf_index` is a `u16` type rather than a `i32`. It seems like the man pages for [`io_uring_prep_write_fixex`](https://man7.org/linux/man-pages/man3/io_uring_prep_write_fixed.3.html) allow for a 32-bit buffer index, and I don't think that there is a 16-bit limit on the number of buffers we are allowed to register (see the man page for [`io_uring_register_buffers`](https://man7.org/linux/man-pages/man3/io_uring_register_buffers.3.html), we are allowed to register an `unsigned` number of buffers).

I don't want to make this PR more than it should be, so I am happy to create another issue for the 2 things I mentioned.