### PR TITLE
relax sq.flags atomic read

### DIFF
--- a/src/submit.rs
+++ b/src/submit.rs
@@ -66,7 +66,7 @@ impl<'a> Submitter<'a> {
     /// CQ ring is overflown
     fn sq_cq_overflow(&self) -> bool {
         unsafe {
-            (*self.sq_flags).load(atomic::Ordering::Acquire) & sys::IORING_SQ_CQ_OVERFLOW != 0
+            (*self.sq_flags).load(atomic::Ordering::Relaxed) & sys::IORING_SQ_CQ_OVERFLOW != 0
         }
     }
 


### PR DESCRIPTION
Change the atomic read of the SQ flags field to be `relaxed`.

Refer to discussions in #197 and in particular, as pointed out in #197, refer to the liburing library loads of this same field.

The liburing library names this field sq.kflags and all its atomic loads are performed with their IO_URING_READ_ONCE macro, which it defines to be the `relaxed` atomic load.