### PR TITLE
unsafe impl `Send+Sync` for `Submitter`, `SubmissionQueue`, `CompletionQueue`

### DIFF
--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -168,6 +168,9 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     // regression test
     tests::regression::test_issue154(&mut ring, &test)?;
 
+    // api tests
+    tests::api::test_sendness(&mut ring, &test)?;
+
     println!("Test count: {}", test.count.get());
 
     Ok(())

--- a/io-uring-test/src/tests/api.rs
+++ b/io-uring-test/src/tests/api.rs
@@ -1,0 +1,20 @@
+use crate::Test;
+use io_uring::IoUring;
+use io_uring::{cqueue, squeue};
+
+pub fn test_sendness<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    _test: &Test,
+) -> anyhow::Result<()> {
+    fn assert_send<T: Send>(t: T) -> T {
+        t
+    }
+
+    let ring = assert_send(ring);
+
+    let (submitter, sq, cq) = ring.split();
+    assert_send(submitter);
+    assert_send(sq);
+    assert_send(cq);
+    Ok(())
+}

--- a/io-uring-test/src/tests/mod.rs
+++ b/io-uring-test/src/tests/mod.rs
@@ -1,3 +1,4 @@
+pub mod api;
 pub mod cancel;
 pub mod fs;
 pub mod futex;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,13 @@ where
 #[derive(Clone)]
 pub struct Parameters(sys::io_uring_params);
 
+/// SAFETY: there isn't anything thread-local about an io_uring instance.
+/// (We do not attempt to model `IORING_SETUP_SINGLE_ISSUER` in the type system.)
 unsafe impl<S: squeue::EntryMarker, C: cqueue::EntryMarker> Send for IoUring<S, C> {}
+/// SAFETY: mutating methods take `&mut self`, thereby eliminating data races between
+/// different userspace borrowers at compile time via standard borrowing rules.
+/// (There are `unsafe` methods like `submission_shared()` and `completion_shared()`
+///  that allow violating this.)
 unsafe impl<S: squeue::EntryMarker, C: cqueue::EntryMarker> Sync for IoUring<S, C> {}
 
 impl IoUring<squeue::Entry, cqueue::Entry> {

--- a/src/squeue.rs
+++ b/src/squeue.rs
@@ -28,10 +28,21 @@ pub struct SubmissionQueue<'a, E: EntryMarker = Entry> {
     queue: &'a Inner<E>,
 }
 
+/// SAFETY: there isn't anything thread-local about the submission queue;
+/// (We do not attempt to model `IORING_SETUP_SINGLE_ISSUER` in the type system.)
+unsafe impl<'a, E: EntryMarker> Send for SubmissionQueue<'a, E> {}
+/// SAFETY: mutating methods take `&mut self`, thereby eliminating data races between
+/// different userspace borrowers at compile time via standard borrowing rules.
+/// (There are `unsafe` methods like `borrow_shared()` that allow violating this.)
+///
+/// The various pointers to atomics are pointers to shared state between
+/// userspace and kernel, and orthogonal to this unsafe impl.
+unsafe impl<'a, E: EntryMarker> Sync for SubmissionQueue<'a, E> {}
+
 /// A submission queue entry (SQE), representing a request for an I/O operation.
 ///
 /// This is implemented for [`Entry`] and [`Entry128`].
-pub trait EntryMarker: Clone + Debug + From<Entry> + private::Sealed {
+pub trait EntryMarker: Send + Clone + Debug + From<Entry> + private::Sealed {
     const BUILD_FLAGS: u32;
 }
 

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -26,6 +26,13 @@ pub struct Submitter<'a> {
     sq_flags: *const atomic::AtomicU32,
 }
 
+/// SAFETY: there isn't anyhting thread-local about submission that would make Send memory unsafe.
+/// (We do not attempt to model `IORING_SETUP_SINGLE_ISSUER` in the type system.)
+unsafe impl<'a> Send for Submitter<'a> {}
+/// SAFETY: [`Submitter`] methods do not manipulate any state themselves (the kernel might do that,
+/// during io_uring_enter, but that's orthogonal to this unsafe impl).
+unsafe impl<'a> Sync for Submitter<'a> {}
+
 impl<'a> Submitter<'a> {
     #[inline]
     pub(crate) const fn new(


### PR DESCRIPTION
The `IoUring` type already has `Send` + `Sync` impls.

In [tokio-epoll-uring](https://github.com/neondatabase/tokio-epoll-uring), we use `split()` and need the `Submitter`, `SubmissionQueue` and `CompletionQueue` to be `Send` (not sync, though).

This PR adds those `unsafe impl`s, and adds hopefully not too repetitive commentary on why these impls are safe.

---------

Co-authored-by: Conrad Ludgate <conrad@neon.tech>
Cherry picked from commit https://github.com/neondatabase/fork--tokio-rs--io-uring/commit/bbc5a0c5f6cde9051037ec2fcc648cbadb7a80b4