### PR TITLE
Fix broken test_udp_recvmsg_multishot_trunc test

### DIFF
--- a/io-uring-test/src/tests/net.rs
+++ b/io-uring-test/src/tests/net.rs
@@ -1459,15 +1459,10 @@ pub fn test_udp_recvmsg_multishot_trunc<S: squeue::EntryMarker, C: cqueue::Entry
     const DATA: &[u8] = b"testfooo for me";
     let mut buf1 = [0u8; 20]; // 20 = size_of::<io_uring_recvmsg_out>() + msghdr.msg_namelen
     let mut buf2 = [0u8; 20 + DATA.len()];
-    let mut buf3 = [0u8; 20 + DATA.len()];
-    let mut buffers = [
-        buf1.as_mut_slice(),
-        buf2.as_mut_slice(),
-        buf3.as_mut_slice(),
-    ];
+    let mut buffers = [buf1.as_mut_slice(), buf2.as_mut_slice()];
 
     for (index, buf) in buffers.iter_mut().enumerate() {
-        let provide_bufs_e = io_uring::opcode::ProvideBuffers::new(
+        let provide_bufs_e = opcode::ProvideBuffers::new(
             (**buf).as_mut_ptr(),
             buf.len() as i32,
             1,
@@ -1479,7 +1474,7 @@ pub fn test_udp_recvmsg_multishot_trunc<S: squeue::EntryMarker, C: cqueue::Entry
         .into();
         unsafe { ring.submission().push(&provide_bufs_e)? };
         ring.submitter().submit_and_wait(1)?;
-        let cqes: Vec<io_uring::cqueue::Entry> = ring.completion().map(Into::into).collect();
+        let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
         assert_eq!(cqes.len(), 1);
         assert_eq!(cqes[0].user_data(), 11);
         assert_eq!(cqes[0].result(), 0);
@@ -1488,7 +1483,7 @@ pub fn test_udp_recvmsg_multishot_trunc<S: squeue::EntryMarker, C: cqueue::Entry
 
     // This structure is actually only used for input arguments to the kernel
     // (and only name length and control length are actually relevant).
-    let mut msghdr: libc::msghdr = unsafe { std::mem::zeroed() };
+    let mut msghdr: libc::msghdr = unsafe { mem::zeroed() };
     msghdr.msg_namelen = 4;
 
     let recvmsg_e = opcode::RecvMsgMulti::new(
@@ -1524,11 +1519,10 @@ pub fn test_udp_recvmsg_multishot_trunc<S: squeue::EntryMarker, C: cqueue::Entry
     ring.submitter().submit().unwrap();
 
     ring.submitter().submit_and_wait(4).unwrap();
-    let cqes: Vec<io_uring::cqueue::Entry> = ring.completion().map(Into::into).collect();
-    assert_eq!(cqes.len(), 4);
-    let mut i = 0;
+    let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
+    assert_eq!(cqes.len(), 5);
     for cqe in cqes {
-        let is_more = io_uring::cqueue::more(cqe.flags());
+        let is_more = cqueue::more(cqe.flags());
         match cqe.user_data() {
             // send notifications
             55 => {
@@ -1537,13 +1531,18 @@ pub fn test_udp_recvmsg_multishot_trunc<S: squeue::EntryMarker, C: cqueue::Entry
             }
             // RecvMsgMulti
             77 => {
+                if cqe.result() == -105 {
+                    // Ran out of buffers
+                    continue;
+                }
+
                 assert!(cqe.result() > 0);
                 assert!(is_more);
-                let buf_id = io_uring::cqueue::buffer_select(cqe.flags()).unwrap();
+                let buf_id = cqueue::buffer_select(cqe.flags()).unwrap();
                 let tmp_buf = &buffers[buf_id as usize];
                 let msg = types::RecvMsgOut::parse(tmp_buf, &msghdr);
 
-                match i {
+                match buf_id {
                     0 => {
                         let msg = msg.unwrap();
                         assert!(msg.is_payload_truncated());
@@ -1564,7 +1563,6 @@ pub fn test_udp_recvmsg_multishot_trunc<S: squeue::EntryMarker, C: cqueue::Entry
                     }
                     _ => unreachable!(),
                 }
-                i += 1;
             }
             _ => {
                 unreachable!()


### PR DESCRIPTION
The bug is that I wasn't using `buf_id` to pick the buffers but rather assumed the kernel would return responses in order.