### PR TITLE
Fix clippy and rustdoc warnings

### DIFF
--- a/src/submit.rs
+++ b/src/submit.rs
@@ -506,7 +506,7 @@ impl<'a> Submitter<'a> {
     /// except that it completes synchronously.
     ///
     /// Cancellation can target a specific request, or all requests matching some criteria. The
-    /// [CancelBuilder](types::CancelBuilder) builder supports describing the match criteria for cancellation.
+    /// [`CancelBuilder`] builder supports describing the match criteria for cancellation.
     ///
     /// An optional `timeout` can be provided to specify how long to wait for matched requests to be
     /// canceled. If no timeout is provided, the default is to wait indefinitely.
@@ -540,14 +540,14 @@ impl<'a> Submitter<'a> {
         let flags = builder.flags.bits();
         let fd = builder.to_fd();
 
-        let arg = {
-            let mut arg = sys::io_uring_sync_cancel_reg::default();
-            arg.addr = user_data;
-            arg.fd = fd;
-            arg.flags = flags;
-            arg.timeout = timespec;
-            arg
+        let arg = sys::io_uring_sync_cancel_reg {
+            addr: user_data,
+            fd,
+            flags,
+            timeout: timespec,
+            ..Default::default()
         };
+
         execute(
             self.fd.as_raw_fd(),
             sys::IORING_REGISTER_SYNC_CANCEL,

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -8,7 +8,7 @@
 #![allow(
     clippy::unreadable_literal,
     clippy::missing_safety_doc,
-    clippy::incorrect_clone_impl_on_copy_type
+    clippy::non_canonical_clone_impl
 )]
 
 use std::io;

--- a/src/types.rs
+++ b/src/types.rs
@@ -396,7 +396,7 @@ impl<'buf> RecvMsgOut<'buf> {
     #[allow(clippy::useless_conversion)]
     pub fn parse(buffer: &'buf [u8], msghdr: &libc::msghdr) -> Result<Self, ()> {
         let msghdr_name_len = usize::try_from(msghdr.msg_namelen).unwrap();
-        let msghdr_control_len = msghdr.msg_controllen;
+        let msghdr_control_len = usize::try_from(msghdr.msg_controllen).unwrap();
 
         if Self::DATA_START
             .checked_add(msghdr_name_len)
@@ -427,7 +427,7 @@ impl<'buf> RecvMsgOut<'buf> {
             let control_data_end = control_start
                 + usize::min(
                     usize::try_from(header.controllen).unwrap(),
-                    usize::try_from(msghdr_control_len).unwrap(),
+                    msghdr_control_len,
                 );
             let control_field_end = control_start + msghdr_control_len;
             (&buffer[control_start..control_data_end], control_field_end)

--- a/src/types.rs
+++ b/src/types.rs
@@ -400,7 +400,7 @@ impl<'buf> RecvMsgOut<'buf> {
 
         if Self::DATA_START
             .checked_add(msghdr_name_len)
-            .and_then(|acc| acc.checked_add(usize::try_from(msghdr.msg_controllen).unwrap()))
+            .and_then(|acc| acc.checked_add(msghdr_control_len))
             .map(|header_len| buffer.len() < header_len)
             .unwrap_or(true)
         {

--- a/src/types.rs
+++ b/src/types.rs
@@ -393,13 +393,14 @@ impl<'buf> RecvMsgOut<'buf> {
     /// is the same content provided as input to the corresponding SQE
     /// (only `msg_namelen` and `msg_controllen` fields are relevant).
     #[allow(clippy::result_unit_err)]
+    #[allow(clippy::useless_conversion)]
     pub fn parse(buffer: &'buf [u8], msghdr: &libc::msghdr) -> Result<Self, ()> {
         let msghdr_name_len = usize::try_from(msghdr.msg_namelen).unwrap();
         let msghdr_control_len = msghdr.msg_controllen;
 
         if Self::DATA_START
             .checked_add(msghdr_name_len)
-            .and_then(|acc| acc.checked_add(msghdr_control_len))
+            .and_then(|acc| acc.checked_add(usize::try_from(msghdr.msg_controllen).unwrap()))
             .map(|header_len| buffer.len() < header_len)
             .unwrap_or(true)
         {

--- a/src/types.rs
+++ b/src/types.rs
@@ -395,7 +395,7 @@ impl<'buf> RecvMsgOut<'buf> {
     #[allow(clippy::result_unit_err)]
     pub fn parse(buffer: &'buf [u8], msghdr: &libc::msghdr) -> Result<Self, ()> {
         let msghdr_name_len = usize::try_from(msghdr.msg_namelen).unwrap();
-        let msghdr_control_len = usize::try_from(msghdr.msg_controllen).unwrap();
+        let msghdr_control_len = msghdr.msg_controllen;
 
         if Self::DATA_START
             .checked_add(msghdr_name_len)

--- a/src/types.rs
+++ b/src/types.rs
@@ -427,7 +427,7 @@ impl<'buf> RecvMsgOut<'buf> {
             let control_data_end = control_start
                 + usize::min(
                     usize::try_from(header.controllen).unwrap(),
-                    msghdr_control_len,
+                    usize::try_from(msghdr_control_len).unwrap(),
                 );
             let control_field_end = control_start + msghdr_control_len;
             (&buffer[control_start..control_data_end], control_field_end)

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,9 @@ use std::{io, ptr};
 
 pub(crate) mod private {
     /// Private trait that we use as a supertrait of `EntryMarker` to prevent it from being
-    /// implemented from outside this crate: https://jack.wrenn.fyi/blog/private-trait-methods/
+    /// implemented from outside this crate.
+    ///
+    /// See this [blog](https://jack.wrenn.fyi/blog/private-trait-methods/) for more details.
     pub trait Sealed {}
 }
 


### PR DESCRIPTION
Fixes a few rustdoc and clippy warnings.

The only thing that might not be good is my removal of the `try_from()` and `unwrap()`, but since it won't type check if the sys type changes I think it's fine.