### PR TITLE
Remove unused kernel diagnostic from io-uring-test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,7 +346,6 @@ dependencies = [
  "io-uring",
  "libc",
  "once_cell",
- "semver",
  "socket2",
  "tempfile",
 ]
@@ -636,12 +635,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"

--- a/io-uring-test/Cargo.toml
+++ b/io-uring-test/Cargo.toml
@@ -13,7 +13,6 @@ anyhow = "1"
 tempfile = "3"
 once_cell = "1"
 socket2 = "0.5"
-semver = "1.0.21"
 
 [features]
 direct-syscall = [ "io-uring/direct-syscall" ]


### PR DESCRIPTION
Hello there! I am a happy user of this library with a small contribution to make. I want to remove a field from the `Test` struct.

The `io-uring-test` crate is broken on any system for which `uname` returns a kernel version that doesn't conform to semver. This includes Fedora Linux, where `uname` might return a `release` such as `6.8.9-300.fc40.x86_64`. I was going to file an issue but then I noticed this code isn't actually used anywhere. By removing this field from `Test` I'd fix the issue for myself and others, while also removing the dependency on the `semver` crate.

