### PR TITLE
Fix nightly compiler complaints about size_of

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,10 @@ mod sys;
 pub mod types;
 
 use std::marker::PhantomData;
+use std::mem::size_of;
 use std::mem::ManuallyDrop;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
-use std::{cmp, io, mem};
+use std::{cmp, io};
 
 #[cfg(feature = "io_safety")]
 use std::os::unix::io::{AsFd, BorrowedFd};
@@ -135,9 +136,9 @@ impl<S: squeue::EntryMarker, C: cqueue::EntryMarker> IoUring<S, C> {
             fd: &OwnedFd,
             p: &sys::io_uring_params,
         ) -> io::Result<(MemoryMap, squeue::Inner<S>, cqueue::Inner<C>)> {
-            let sq_len = p.sq_off.array as usize + p.sq_entries as usize * mem::size_of::<u32>();
-            let cq_len = p.cq_off.cqes as usize + p.cq_entries as usize * mem::size_of::<C>();
-            let sqe_len = p.sq_entries as usize * mem::size_of::<S>();
+            let sq_len = p.sq_off.array as usize + p.sq_entries as usize * size_of::<u32>();
+            let cq_len = p.cq_off.cqes as usize + p.cq_entries as usize * size_of::<C>();
+            let sqe_len = p.sq_entries as usize * size_of::<S>();
             let sqe_mmap = Mmap::new(fd, sys::IORING_OFF_SQES as _, sqe_len)?;
 
             if p.features & sys::IORING_FEAT_SINGLE_MMAP != 0 {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -4,6 +4,7 @@
 
 use std::convert::TryInto;
 use std::mem;
+use std::mem::size_of;
 use std::os::unix::io::RawFd;
 
 use crate::squeue::Entry;
@@ -1106,7 +1107,7 @@ opcode! {
         sqe.opcode = Self::CODE;
         sqe.fd = dirfd;
         sqe.__bindgen_anon_2.addr = pathname as _;
-        sqe.len = mem::size_of::<sys::open_how>() as _;
+        sqe.len = size_of::<sys::open_how>() as _;
         sqe.__bindgen_anon_1.off = how as _;
         if let Some(dest) = file_index {
             sqe.__bindgen_anon_5.file_index = dest.kernel_index_arg();

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -1,6 +1,7 @@
+use std::mem::size_of;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::atomic;
-use std::{io, mem, ptr};
+use std::{io, ptr};
 
 use crate::register::{execute, Probe};
 use crate::sys;
@@ -91,7 +92,7 @@ impl<'a> Submitter<'a> {
         let arg = arg
             .map(|arg| cast_ptr(arg).cast())
             .unwrap_or_else(ptr::null);
-        let size = mem::size_of::<T>();
+        let size = size_of::<T>();
         sys::io_uring_enter(
             self.fd.as_raw_fd(),
             to_submit,
@@ -210,7 +211,7 @@ impl<'a> Submitter<'a> {
             self.fd.as_raw_fd(),
             sys::IORING_REGISTER_FILES2,
             cast_ptr::<sys::io_uring_rsrc_register>(&rr).cast(),
-            mem::size_of::<sys::io_uring_rsrc_register>() as _,
+            size_of::<sys::io_uring_rsrc_register>() as _,
         )
         .map(drop)
     }
@@ -411,7 +412,7 @@ impl<'a> Submitter<'a> {
             self.fd.as_raw_fd(),
             sys::IORING_REGISTER_IOWQ_AFF,
             cpu_set as *const _ as *const libc::c_void,
-            mem::size_of::<libc::cpu_set_t>() as u32,
+            size_of::<libc::cpu_set_t>() as u32,
         )
         .map(drop)
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,7 @@
 //! Common Linux types not provided by libc.
 
+use std::mem::size_of;
+
 pub(crate) mod sealed {
     use super::{Fd, Fixed};
     use std::os::unix::io::RawFd;
@@ -250,7 +252,7 @@ impl<'prev, 'now> SubmitArgs<'prev, 'now> {
     #[inline]
     pub fn sigmask<'new>(mut self, sigmask: &'new libc::sigset_t) -> SubmitArgs<'now, 'new> {
         self.args.sigmask = cast_ptr(sigmask) as _;
-        self.args.sigmask_sz = std::mem::size_of::<libc::sigset_t>() as _;
+        self.args.sigmask_sz = size_of::<libc::sigset_t>() as _;
 
         SubmitArgs {
             args: self.args,
@@ -385,7 +387,7 @@ pub struct RecvMsgOut<'buf> {
 }
 
 impl<'buf> RecvMsgOut<'buf> {
-    const DATA_START: usize = std::mem::size_of::<sys::io_uring_recvmsg_out>();
+    const DATA_START: usize = size_of::<sys::io_uring_recvmsg_out>();
 
     /// Parse the data buffered upon completion of a `RecvMsg` multishot operation.
     ///


### PR DESCRIPTION
Because the prelude now includes size_of, the nightly compiler really doesn't like it when you fully qualify size_of.