### PR TITLE
Implement the equivalent of `io_uring_prep_sendto`

### DIFF
--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -134,6 +134,7 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     tests::net::test_socket(&mut ring, &test)?;
     tests::net::test_udp_recvmsg_multishot(&mut ring, &test)?;
     tests::net::test_udp_recvmsg_multishot_trunc(&mut ring, &test)?;
+    tests::net::test_udp_send_with_dest(&mut ring, &test)?;
     tests::net::test_udp_sendzc_with_dest(&mut ring, &test)?;
 
     // queue

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1003,18 +1003,27 @@ opcode! {
         buf: { *const u8 },
         len: { u32 },
         ;;
-        flags: i32 = 0
+        flags: i32 = 0,
+
+        /// Set the destination address, for sending from an unconnected socket.
+        ///
+        /// When set, `dest_addr_len` must be set as well.
+        /// See also `man 3 io_uring_prep_send_set_addr`.
+        dest_addr: *const libc::sockaddr = core::ptr::null(),
+        dest_addr_len: libc::socklen_t = 0,
     }
 
     pub const CODE = sys::IORING_OP_SEND;
 
     pub fn build(self) -> Entry {
-        let Send { fd, buf, len, flags } = self;
+        let Send { fd, buf, len, flags, dest_addr, dest_addr_len } = self;
 
         let mut sqe = sqe_zeroed();
         sqe.opcode = Self::CODE;
         assign_fd!(sqe.fd = fd);
         sqe.__bindgen_anon_2.addr = buf as _;
+        sqe.__bindgen_anon_1.addr2 = dest_addr as _;
+        sqe.__bindgen_anon_5.__bindgen_anon_1.addr_len = dest_addr_len as _;
         sqe.len = len;
         sqe.__bindgen_anon_3.msg_flags = flags as _;
         Entry(sqe)


### PR DESCRIPTION
In liburing, there is [`io_uring_prep_sendto`](https://github.com/axboe/liburing/blob/25b3d2d428bb6b374a4feea02ff488d41a7ba5a1/src/include/liburing.h#L873-L880), which is implemented as preparing a regular `send` followed by `set_addr` on the same SQE. This was not yet implemented here for `Send`, so add it.

Fortunately @serzhiio previously implemented the equivalent for `SendZc` in #228, so it was easy to adapt that for `Send`. Thanks serzhiio, this saved me a lot of time!