### PR TITLE
Add support for ftruncate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,9 +358,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.156"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5f43f184355eefb8d17fc948dbecf6c13be3c141f20d834ae842193a448c72a"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "libloading"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ io_safety = []
 bitflags = "2"
 cfg-if = "1"
 
-libc = { version = "0.2.98", default-features = false }
+libc = { version = "0.2.167", default-features = false }
 sc = { version = "0.2", optional = true }
 
 [build-dependencies]

--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -103,6 +103,7 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     #[cfg(not(feature = "ci"))]
     tests::fs::test_statx(&mut ring, &test)?;
     tests::fs::test_file_splice(&mut ring, &test)?;
+    tests::fs::test_file_ftruncate(&mut ring, &test)?;
 
     // timeout
     tests::timeout::test_timeout(&mut ring, &test)?;

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1847,3 +1847,27 @@ opcode! {
         Entry(sqe)
     }
 }
+
+// === 6.9 ===
+
+opcode! {
+    /// Truncate a file to a specified length, equivalent to `ftruncate(2)`.
+    #[derive(Debug)]
+    pub struct Ftruncate {
+        fd: { impl sealed::UseFixed },
+        len: { u64 },
+        ;;
+    }
+
+    pub const CODE = sys::IORING_OP_FTRUNCATE;
+
+    pub fn build(self) -> Entry {
+        let Ftruncate { fd, len } = self;
+
+        let mut sqe = sqe_zeroed();
+        sqe.opcode = Self::CODE;
+        assign_fd!(sqe.fd = fd);
+        sqe.__bindgen_anon_1.off = len;
+        Entry(sqe)
+    }
+}


### PR DESCRIPTION
Introduces `opcode::Ftruncate` to support `ftruncate` which got supported since Linux 6.9.

Also updates the libc to the latest version to get the new sys::IORING_OP_FTRUNCATE flag from libc.

See

- `IORING_OP_FTRUNCATE` commit: https://github.com/torvalds/linux/commit/b4bb1900c12e6a0fe11ff51e1aa6eea19a4ad635
- liburing PR: https://github.com/axboe/liburing/pull/1004