### PR TITLE
feat: Support `IORING_TIMEOUT_MULTISHOT` flag

### DIFF
--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -115,6 +115,7 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     tests::timeout::test_timeout_cancel(&mut ring, &test)?;
     tests::timeout::test_timeout_abs(&mut ring, &test)?;
     tests::timeout::test_timeout_submit_args(&mut ring, &test)?;
+    tests::timeout::test_timeout_multishot(&mut ring, &test)?;
 
     // net
     tests::net::test_tcp_write_read(&mut ring, &test)?;

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -543,9 +543,10 @@ opcode! {
         timespec: { *const types::Timespec },
         ;;
         /// `count` may contain a completion event count.
+        /// If [`TimeoutFlags::TIMEOUT`] is set in `flags`, this is the number of repeats. A value of 0 means the timeout is
+        /// indefinite and can only be stopped by a removal request.
         count: u32 = 0,
 
-        /// `flags` may contain [types::TimeoutFlags::ABS] for an absolute timeout value, or 0 for a relative timeout.
         flags: types::TimeoutFlags = types::TimeoutFlags::empty()
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -99,6 +99,8 @@ bitflags! {
         const LINK_TIMEOUT_UPDATE = sys::IORING_LINK_TIMEOUT_UPDATE;
 
         const ETIME_SUCCESS = sys::IORING_TIMEOUT_ETIME_SUCCESS;
+
+        const MULTISHOT = sys::IORING_TIMEOUT_MULTISHOT;
     }
 }
 


### PR DESCRIPTION
I've also removed the comment for `flags` which was already non-exhaustive (meaning doesn't cover `ETIME_SUCCESS` , `BOOTTIME`, or `REALTIME`). I think it's better to leave the description of the possible flags in `TimeoutFlags` instead so as to avoid duplicating this information to every field that uses said type

Closes #331 