### PR TITLE
Add missing `register_files` APIs

### DIFF
--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -75,6 +75,8 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     // register
     tests::register::test_register_files_sparse(&mut ring, &test)?;
+    tests::register::test_register_files_tags(&mut ring, &test)?;
+    tests::register::test_register_files_update_tag(&mut ring, &test)?;
     tests::register_buffers::test_register_buffers(&mut ring, &test)?;
     tests::register_buffers::test_register_buffers_update(&mut ring, &test)?;
     tests::register_buf_ring::test_register_buf_ring(&mut ring, &test)?;

--- a/io-uring-test/src/tests/register.rs
+++ b/io-uring-test/src/tests/register.rs
@@ -1,5 +1,8 @@
+use std::os::fd::AsRawFd;
+use anyhow::{bail, Context};
 use crate::Test;
 use io_uring::{cqueue, opcode, squeue, IoUring};
+use io_uring::cqueue::Entry;
 
 pub fn test_register_files_sparse<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     ring: &mut IoUring<S, C>,
@@ -66,5 +69,145 @@ pub fn test_register_files_sparse<S: squeue::EntryMarker, C: cqueue::EntryMarker
         ));
     }
 
+    Ok(())
+}
+
+pub fn test_register_files_tags<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
+    // register_files_sparse was introduced in kernel 5.13, we need to check if resource tagging
+    // is available.
+    require!(
+        test;
+        ring.params().is_feature_resource_tagging();
+    );
+
+    println!("test register_files_tags");
+
+    let file1 = tempfile::tempfile()?;
+    let file2 = tempfile::tempfile()?;
+    let file3 = tempfile::tempfile()?;
+
+    let descriptors = &[
+        file1.as_raw_fd(),
+        file2.as_raw_fd(),
+        file3.as_raw_fd(),
+    ];
+
+    let flags = &[0, 1, 2];
+
+    ring.submitter()
+        .register_files_tags(descriptors, flags)
+        .context("register_files_tags failed")?;
+
+    // See that same call again, with any value, will fail because a direct table cannot be built
+    // over an existing one.
+    if let Ok(()) = ring.submitter().register_files_tags(descriptors, flags) {
+        bail!("register_files_tags should not have succeeded twice in a row");
+    }
+
+    // See that the direct table can be removed.
+    ring.submitter()
+        .unregister_files()
+        .context("unregister_files failed")?;
+
+    // See that a second attempt to remove the direct table would fail.
+    if let Ok(()) = ring.submitter().unregister_files() {
+        bail!("should not have succeeded twice in a row");
+    }
+    
+    // Check that we get completion events for unregistering files with non-zero tags.
+    let mut completion = ring.completion();
+    completion.sync();
+    
+    let cqes = completion
+        .map(Into::into)
+        .collect::<Vec<Entry>>();
+    
+    if cqes.len() != 2 {
+        bail!("incorrect number of completion events: {cqes:?}")
+    }
+    
+    for event in cqes {
+        if event.flags() != 0 || event.result() != 0 {
+            bail!(
+                "completion events from unregistering tagged \
+                files should have zeroed flags and result fields"
+            );
+        }
+
+        let tag = event.user_data();
+        if !(1..3).contains(&tag) {
+            bail!("completion event user data does not contain one of the possible tag values")
+        }
+    }
+
+    Ok(())
+}
+
+pub fn test_register_files_update_tag<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
+    // register_files_update_tag was introduced in kernel 5.13, we need to check if resource tagging
+    // is available.
+    require!(
+        test;
+        ring.params().is_feature_resource_tagging();
+    );
+    
+    println!("test register_files_update_tag");
+    
+    let descriptors = &[
+        -1,
+        -1,
+        -1,
+    ];    
+    let flags = &[0, 0, 0];    
+    ring.submitter()
+        .register_files_tags(descriptors, flags)
+        .context("register_files_tags failed")?;
+
+    let file = tempfile::tempfile()
+        .context("create temp file")?;
+    
+    // Update slot `1` with a tagged file
+    ring.submitter()
+        .register_files_update_tag(1, &[file.as_raw_fd()], &[1])
+        .context("register_files_update_tag failed")?;
+
+    // Update slot `2` with an untagged file
+    ring.submitter()
+        .register_files_update_tag(1, &[file.as_raw_fd()], &[0])
+        .context("register_files_update_tag failed")?;
+    
+    ring.submitter()
+        .unregister_files()
+        .context("unregister_files failed")?;
+
+    // Check that we get completion events for unregistering files with non-zero tags.
+    let mut completion = ring.completion();
+    completion.sync();
+    
+    let cqes = completion
+        .map(Into::into)
+        .collect::<Vec<Entry>>();
+
+    if cqes.len() != 1 {
+        bail!("incorrect number of completion events: {cqes:?}")
+    }
+    
+    if cqes[0].result() != 0 || cqes[0].flags() != 0 {
+        bail!(
+            "completion events from unregistering tagged \
+            files should have zeroed flags and result fields"
+        );
+    }
+
+    if cqes[0].user_data() != 1 {
+        bail!("completion event user data does not contain tag of registered file");
+    }
+    
     Ok(())
 }


### PR DESCRIPTION
This PR adds two missing ring calls, `io_uring_register_files_tags` and `io_uring_register_files_update_tag`. 

Tests have been added and confirmed working, I also adjusted part of the docs for `register_files` to more accurately note the behaviour of the call.