### PR TITLE
feat: support xattr related opcodes

### DIFF
--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -106,6 +106,8 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     tests::fs::test_file_splice(&mut ring, &test)?;
     tests::fs::test_ftruncate(&mut ring, &test)?;
     tests::fs::test_fixed_fd_install(&mut ring, &test)?;
+    tests::fs::test_get_set_xattr(&mut ring, &test)?;
+    tests::fs::test_f_get_set_xattr(&mut ring, &test)?;
 
     // timeout
     tests::timeout::test_timeout(&mut ring, &test)?;

--- a/io-uring-test/src/tests/fs.rs
+++ b/io-uring-test/src/tests/fs.rs
@@ -937,3 +937,146 @@ pub fn test_fixed_fd_install<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     Ok(())
 }
+
+pub fn test_get_set_xattr<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
+    require!(
+        test;
+        test.probe.is_supported(opcode::GetXattr::CODE);
+        test.probe.is_supported(opcode::SetXattr::CODE);
+    );
+
+    println!("test get_set_xattr");
+
+    let dir = tempfile::tempdir()?;
+    let file_path = dir.path().join("test-file");
+    fs::write(&file_path, b"test content")?;
+
+    let file_path_cstr = CString::new(file_path.as_os_str().as_bytes())?;
+
+    let attr_name = CString::new("user.test_attr")?;
+    let attr_value = CString::new("test_value")?;
+    let mut buffer = vec![0u8; 128];
+
+    // Set extended attribute
+    let setxattr_e = opcode::SetXattr::new(
+        attr_name.as_ptr(),
+        attr_value.as_ptr().cast(),
+        file_path_cstr.as_ptr().cast(),
+        attr_value.as_bytes().len() as u32,
+    )
+    .flags(0)
+    .build()
+    .user_data(0x01)
+    .into();
+
+    unsafe {
+        ring.submission().push(&setxattr_e).expect("queue is full");
+    }
+
+    ring.submit_and_wait(1)?;
+
+    let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
+    assert_eq!(cqes.len(), 1);
+    assert_eq!(cqes[0].user_data(), 0x01);
+    assert_eq!(cqes[0].result(), 0);
+
+    // Get extended attribute
+    let getxattr_e = opcode::GetXattr::new(
+        attr_name.as_ptr(),
+        buffer.as_mut_ptr().cast(),
+        file_path_cstr.as_ptr().cast(),
+        buffer.len() as u32,
+    )
+    .build()
+    .user_data(0x02)
+    .into();
+
+    unsafe {
+        ring.submission().push(&getxattr_e).expect("queue is full");
+    }
+
+    ring.submit_and_wait(1)?;
+
+    let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
+    assert_eq!(cqes.len(), 1);
+    assert_eq!(cqes[0].user_data(), 0x02);
+    assert_eq!(cqes[0].result(), attr_value.as_bytes().len() as i32);
+
+    let retrieved_value = CString::new(&buffer[..cqes[0].result() as usize])?;
+    assert_eq!(retrieved_value, attr_value);
+
+    Ok(())
+}
+
+pub fn test_f_get_set_xattr<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
+    require!(
+        test;
+        test.probe.is_supported(opcode::FGetXattr::CODE);
+        test.probe.is_supported(opcode::FSetXattr::CODE);
+    );
+
+    println!("test f_get_set_xattr");
+
+    let file = tempfile::tempfile()?;
+    let fd = types::Fd(file.as_raw_fd());
+
+    let attr_name = CString::new("user.test_attr")?;
+    let attr_value = CString::new("test_value")?;
+    let mut buffer = vec![0u8; 128];
+
+    // Set extended attribute on file descriptor
+    let fsetxattr_e = opcode::FSetXattr::new(
+        fd,
+        attr_name.as_ptr(),
+        attr_value.as_ptr().cast(),
+        attr_value.as_bytes().len() as u32,
+    )
+    .flags(0)
+    .build()
+    .user_data(0x01)
+    .into();
+
+    unsafe {
+        ring.submission().push(&fsetxattr_e).expect("queue is full");
+    }
+
+    ring.submit_and_wait(1)?;
+
+    let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
+    assert_eq!(cqes.len(), 1);
+    assert_eq!(cqes[0].user_data(), 0x01);
+    assert_eq!(cqes[0].result(), 0);
+
+    // Get extended attribute from file descriptor
+    let fgetxattr_e = opcode::FGetXattr::new(
+        fd,
+        attr_name.as_ptr(),
+        buffer.as_mut_ptr().cast(),
+        buffer.len() as u32,
+    )
+    .build()
+    .user_data(0x02)
+    .into();
+
+    unsafe {
+        ring.submission().push(&fgetxattr_e).expect("queue is full");
+    }
+
+    ring.submit_and_wait(1)?;
+
+    let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
+    assert_eq!(cqes.len(), 1);
+    assert_eq!(cqes[0].user_data(), 0x02);
+    assert_eq!(cqes[0].result(), attr_value.as_bytes().len() as i32);
+
+    let retrieved_value = CString::new(&buffer[..cqes[0].result() as usize])?;
+    assert_eq!(retrieved_value, attr_value);
+
+    Ok(())
+}

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1466,6 +1466,114 @@ opcode! {
     }
 }
 
+// === 5.17 ===
+
+opcode! {
+    /// Get extended attribute, equivalent to `getxattr(2)`.
+    pub struct GetXattr {
+        name: { *const libc::c_char },
+        value: { *mut libc::c_void },
+        path: { *const libc::c_char },
+        len: { u32 },
+        ;;
+    }
+
+    pub const CODE = sys::IORING_OP_GETXATTR;
+
+    pub fn build(self) -> Entry {
+        let GetXattr { name, value, path, len } = self;
+
+        let mut sqe = sqe_zeroed();
+        sqe.opcode = Self::CODE;
+        sqe.__bindgen_anon_2.addr = name as _;
+        sqe.len = len;
+        sqe.__bindgen_anon_1.off = value as _;
+        unsafe { sqe.__bindgen_anon_6.__bindgen_anon_1.as_mut().addr3 = path as _ };
+        sqe.__bindgen_anon_3.xattr_flags = 0;
+        Entry(sqe)
+    }
+}
+
+opcode! {
+    /// Set extended attribute, equivalent to `setxattr(2)`.
+    pub struct SetXattr {
+        name: { *const libc::c_char },
+        value: { *const libc::c_void },
+        path: { *const libc::c_char },
+        len: { u32 },
+        ;;
+        flags: i32 = 0
+    }
+
+    pub const CODE = sys::IORING_OP_SETXATTR;
+
+    pub fn build(self) -> Entry {
+        let SetXattr { name, value, path, flags, len } = self;
+
+        let mut sqe = sqe_zeroed();
+        sqe.opcode = Self::CODE;
+        sqe.__bindgen_anon_2.addr = name as _;
+        sqe.len = len;
+        sqe.__bindgen_anon_1.off = value as _;
+        unsafe { sqe.__bindgen_anon_6.__bindgen_anon_1.as_mut().addr3 = path as _ };
+        sqe.__bindgen_anon_3.xattr_flags = flags as _;
+        Entry(sqe)
+    }
+}
+
+opcode! {
+    /// Get extended attribute from a file descriptor, equivalent to `fgetxattr(2)`.
+    pub struct FGetXattr {
+        fd: { impl sealed::UseFixed },
+        name: { *const libc::c_char },
+        value: { *mut libc::c_void },
+        len: { u32 },
+        ;;
+    }
+
+    pub const CODE = sys::IORING_OP_FGETXATTR;
+
+    pub fn build(self) -> Entry {
+        let FGetXattr { fd, name, value, len } = self;
+
+        let mut sqe = sqe_zeroed();
+        sqe.opcode = Self::CODE;
+        assign_fd!(sqe.fd = fd);
+        sqe.__bindgen_anon_2.addr = name as _;
+        sqe.len = len;
+        sqe.__bindgen_anon_1.off = value as _;
+        sqe.__bindgen_anon_3.xattr_flags = 0;
+        Entry(sqe)
+    }
+}
+
+opcode! {
+    /// Set extended attribute on a file descriptor, equivalent to `fsetxattr(2)`.
+    pub struct FSetXattr {
+        fd: { impl sealed::UseFixed },
+        name: { *const libc::c_char },
+        value: { *const libc::c_void },
+        len: { u32 },
+        ;;
+        flags: i32 = 0
+    }
+
+    pub const CODE = sys::IORING_OP_FSETXATTR;
+
+    pub fn build(self) -> Entry {
+        let FSetXattr { fd, name, value, flags, len } = self;
+
+        let mut sqe = sqe_zeroed();
+        sqe.opcode = Self::CODE;
+        assign_fd!(sqe.fd = fd);
+        sqe.__bindgen_anon_2.addr = name as _;
+        sqe.len = len;
+        sqe.__bindgen_anon_1.off = value as _;
+        sqe.__bindgen_anon_3.xattr_flags = flags as _;
+        Entry(sqe)
+    }
+}
+
 // === 5.18 ===
 
 opcode! {


### PR DESCRIPTION
Closes #339 

This PR implements opcodes builder implementation for `GetXattr`, `SetXattr`, `FGetXattr`, `FSetXattr`, and includes tests for them.