### PR TITLE
Add missing getter in SubmitArgs.

### DIFF
--- a/src/submit.rs
+++ b/src/submit.rs
@@ -188,7 +188,7 @@ impl<'a> Submitter<'a> {
             }
         }
 
-        unsafe { self.enter(len as _, want as _, flags, Some(&args.args)) }
+        unsafe { self.enter(len as _, want as _, flags, Some(args)) }
     }
 
     /// Wait for the submission queue to have free entries.

--- a/src/types.rs
+++ b/src/types.rs
@@ -239,6 +239,7 @@ impl From<std::time::Duration> for Timespec {
 ///
 /// drop(args);
 /// ```
+#[repr(transparent)]
 #[derive(Default, Debug, Clone, Copy)]
 pub struct SubmitArgs<'prev: 'now, 'now> {
     pub(crate) args: sys::io_uring_getevents_arg,


### PR DESCRIPTION
Need to expose the `SubmitArgs::get_args()` getter because I can't implement missing `liburing` cqe helpers like this one otherwise. 

Makes it easier than working directly with `sys::io_uring_getevents_arg`.

```rust
    // Expose missing cqes only enter methods from `liburing`.
    pub fn wait_cqes_timeout(&self, min_complete: u32, timeout: Duration) -> Result<usize> {
        let flags = sys::IORING_ENTER_EXT_ARG | sys::IORING_ENTER_GETEVENTS;

        let ts = types::Timespec::from(timeout);
        let args = types::SubmitArgs::new().timespec(&ts);

        unsafe {
            self.ring
                .submitter()
                .enter(0, to_complete, flags, Some(&args.args)) // <--- private field !!
        }
    }
```