### PR TITLE
WaitId mutates infop; change op to take mut ptr

### DIFF
--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2023,7 +2023,7 @@ opcode! {
         id: { libc::id_t },
         options: { libc::c_int },
         ;;
-        infop: *const libc::siginfo_t = std::ptr::null(),
+        infop: *mut libc::siginfo_t = std::ptr::null_mut(),
         flags: libc::c_uint = 0,
     }
 


### PR DESCRIPTION
While working on https://github.com/axboe/liburing/pull/1468 I noticed that the `WaitId` op allows specifying `infop: *const siginfo_t` but this is incorrect because the `siginfo_t` is mutated.

(There may be other cases like this in some of the ops, I haven't checked everything).

This PR updates the method with the correct mutability and adds a test demonstrating a mutation.