### PR TITLE
Public re-export for submit::EnterFlags.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ use std::os::unix::io::{AsFd, BorrowedFd};
 pub use cqueue::CompletionQueue;
 pub use register::Probe;
 pub use squeue::SubmissionQueue;
+pub use submit::EnterFlags;
 pub use submit::Submitter;
 use util::{Mmap, OwnedFd};
 


### PR DESCRIPTION
Did not realize `submit` module was private.

Tested in my project with Cargo.toml:
`io-uring = { git = "https://github.com/sugarraysam/io-uring.git", branch = "origin/expose-enter-flags" }`