### PR TITLE
Origin/entry can clear flags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ use std::os::unix::io::{AsFd, BorrowedFd};
 pub use cqueue::CompletionQueue;
 pub use register::Probe;
 pub use squeue::SubmissionQueue;
+pub use submit::EnterFlags;
 pub use submit::Submitter;
 use util::{Mmap, OwnedFd};
 

--- a/src/squeue.rs
+++ b/src/squeue.rs
@@ -328,6 +328,13 @@ impl Entry {
         self
     }
 
+    /// Clear the submission event's [flags](Flags).
+    #[inline]
+    pub fn clear_flags(mut self) -> Entry {
+        self.0.flags = 0;
+        self
+    }
+
     /// Set the user data. This is an application-supplied value that will be passed straight
     /// through into the [completion queue entry](crate::cqueue::Entry::user_data).
     #[inline]
@@ -379,6 +386,13 @@ impl Entry128 {
     #[inline]
     pub fn flags(mut self, flags: Flags) -> Entry128 {
         self.0 .0.flags |= flags.bits();
+        self
+    }
+
+    /// Clear the submission event's [flags](Flags).
+    #[inline]
+    pub fn clear_flags(mut self) -> Entry128 {
+        self.0 .0.flags = 0;
         self
     }
 


### PR DESCRIPTION
Just a convenience function.

I have a workaround and I'm not block on this, but while working with Entries I realized you can only "augment" the flags of an entry. My use case is I was building a chain of SQE dynamically with the `Flags::IO_LINK` flag, and need to `clear_flags()` on the last entry to end the chain.