### PR TITLE
Add Entry::get_opcode().

### DIFF
--- a/src/squeue.rs
+++ b/src/squeue.rs
@@ -342,6 +342,12 @@ impl Entry {
         self.0.user_data
     }
 
+    /// Get the opcode associated with this entry.
+    #[inline]
+    pub fn get_opcode(&self) -> u32 {
+        self.0.opcode.into()
+    }
+
     /// Set the personality of this event. You can obtain a personality using
     /// [`Submitter::register_personality`](crate::Submitter::register_personality).
     pub fn personality(mut self, personality: u16) -> Entry {
@@ -396,6 +402,12 @@ impl Entry128 {
     pub fn personality(mut self, personality: u16) -> Entry128 {
         self.0 .0.personality = personality;
         self
+    }
+
+    /// Get the opcode associated with this entry.
+    #[inline]
+    pub fn get_opcode(&self) -> u32 {
+        self.0 .0.opcode.into()
     }
 }
 


### PR DESCRIPTION
As titled.

I found to work with the library, it's easier to accept `Entry` in functions because it can contain any of the opcode. Whereas accepting opcode directly requires generics and does not work when you need type-erasure.

Anyhow, knowing which "flavor" of entry you have is essential to do validation.