### PR TITLE
Entry getters and setters

### DIFF
--- a/src/squeue.rs
+++ b/src/squeue.rs
@@ -328,6 +328,13 @@ impl Entry {
         self
     }
 
+    /// Clear the submission event's [flags](Flags).
+    #[inline]
+    pub fn clear_flags(mut self) -> Entry {
+        self.0.flags = 0;
+        self
+    }
+
     /// Set the user data. This is an application-supplied value that will be passed straight
     /// through into the [completion queue entry](crate::cqueue::Entry::user_data).
     #[inline]
@@ -336,10 +343,22 @@ impl Entry {
         self
     }
 
+    /// Set the user_data without consuming the entry.
+    #[inline]
+    pub fn set_user_data(&mut self, user_data: u64) {
+        self.0.user_data = user_data;
+    }
+
     /// Get the previously application-supplied user data.
     #[inline]
     pub fn get_user_data(&self) -> u64 {
         self.0.user_data
+    }
+
+    /// Get the opcode associated with this entry.
+    #[inline]
+    pub fn get_opcode(&self) -> u32 {
+        self.0.opcode.into()
     }
 
     /// Set the personality of this event. You can obtain a personality using
@@ -382,6 +401,13 @@ impl Entry128 {
         self
     }
 
+    /// Clear the submission event's [flags](Flags).
+    #[inline]
+    pub fn clear_flags(mut self) -> Entry128 {
+        self.0 .0.flags = 0;
+        self
+    }
+
     /// Set the user data. This is an application-supplied value that will be passed straight
     /// through into the [completion queue entry](crate::cqueue::Entry::user_data).
     #[inline]
@@ -390,12 +416,24 @@ impl Entry128 {
         self
     }
 
+    /// Set the user data without consuming the entry.
+    #[inline]
+    pub fn set_user_data(&mut self, user_data: u64) {
+        self.0 .0.user_data = user_data;
+    }
+
     /// Set the personality of this event. You can obtain a personality using
     /// [`Submitter::register_personality`](crate::Submitter::register_personality).
     #[inline]
     pub fn personality(mut self, personality: u16) -> Entry128 {
         self.0 .0.personality = personality;
         self
+    }
+
+    /// Get the opcode associated with this entry.
+    #[inline]
+    pub fn get_opcode(&self) -> u32 {
+        self.0 .0.opcode.into()
     }
 }
 


### PR DESCRIPTION
Adding a few convenience functions.

(1) `set_user_data` is useful for SQ push retries. Most applications working with iouring use a Slab or other indexed storage to bridge between SQ ring and CQ ring. If you retry, you have to re-index stuff, thus mutating the user_data becomes really convenient (see: https://gist.github.com/sugarraysam/01008d85a418aa71a5aac04ce2a1a623)

(2) `clear_flags` is convenience as well. API only allows "augmenting" the flags with `|=` so at least now we can reset.

(3) `get_opcode` this was hidden and is good to see if you get an opaque Entry.