### PR TITLE
register: Add register_napi/unregister_napi methods

### DIFF
--- a/src/submit.rs
+++ b/src/submit.rs
@@ -753,4 +753,39 @@ impl<'a> Submitter<'a> {
         )
         .map(drop)
     }
+
+    /// Register NAPI busy-poll settings on this io_uring ring.
+    ///
+    /// The kernel writes the previous settings back to `napi` before
+    /// applying the new ones.
+    ///
+    /// Available since Linux 6.9.
+    pub fn register_napi(&self, napi: &mut sys::io_uring_napi) -> io::Result<()> {
+        execute(
+            self.fd.as_raw_fd(),
+            sys::IORING_REGISTER_NAPI,
+            (napi as *mut sys::io_uring_napi).cast::<libc::c_void>().cast_const(),
+            1,
+        )
+        .map(drop)
+    }
+
+    /// Unregister NAPI busy-poll from this io_uring ring.
+    ///
+    /// If `napi` is `Some`, the kernel writes the current settings back
+    /// before disabling.
+    ///
+    /// Available since Linux 6.9.
+    pub fn unregister_napi(&self, napi: Option<&mut sys::io_uring_napi>) -> io::Result<()> {
+        let (ptr, len) = match napi {
+            Some(n) => (
+                (n as *mut sys::io_uring_napi)
+                    .cast::<libc::c_void>()
+                    .cast_const(),
+                1,
+            ),
+            None => (ptr::null(), 0),
+        };
+        execute(self.fd.as_raw_fd(), sys::IORING_UNREGISTER_NAPI, ptr, len).map(drop)
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -51,9 +51,10 @@ use std::os::unix::io::RawFd;
 #[deprecated]
 pub type RwFlags = u32;
 pub use sys::{
-    io_uring_region_desc, io_uring_zcrx_area_reg, io_uring_zcrx_cqe, io_uring_zcrx_ifq_reg,
-    io_uring_zcrx_rqe, IORING_MEM_REGION_TYPE_USER, IORING_ZCRX_AREA_SHIFT, IOU_PBUF_RING_INC,
-    IOU_PBUF_RING_MMAP,
+    io_uring_napi, io_uring_region_desc, io_uring_zcrx_area_reg, io_uring_zcrx_cqe,
+    io_uring_zcrx_ifq_reg, io_uring_zcrx_rqe, IORING_MEM_REGION_TYPE_USER,
+    IORING_ZCRX_AREA_SHIFT, IO_URING_NAPI_REGISTER_OP, IO_URING_NAPI_TRACKING_DYNAMIC,
+    IO_URING_NAPI_TRACKING_STATIC, IOU_PBUF_RING_INC, IOU_PBUF_RING_MMAP,
 };
 
 // From linux/io_uring.h


### PR DESCRIPTION
Expose IORING_REGISTER_NAPI (opcode 27) and IORING_UNREGISTER_NAPI (opcode 28) through the Submitter API. These allow configuring per-ring NAPI busy-poll, where io_uring_enter() polls NAPI instances on the calling CPU before blocking for completions.

register_napi takes a mutable reference since the kernel writes the previous settings back to the struct. unregister_napi optionally accepts a struct to receive the current settings before disabling.

Re-export io_uring_napi and associated constants through the public types module.

Available since Linux 6.9.