### PR TITLE
feat: add ioprio method for Send and Recv

### DIFF
--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1034,6 +1034,7 @@ opcode! {
         buf: { *const u8 },
         len: { u32 },
         ;;
+        ioprio: u16 = 0,
         flags: i32 = 0,
 
         /// Set the destination address, for sending from an unconnected socket.
@@ -1047,7 +1048,7 @@ opcode! {
     pub const CODE = sys::IORING_OP_SEND;
 
     pub fn build(self) -> Entry {
-        let Send { fd, buf, len, flags, dest_addr, dest_addr_len } = self;
+        let Send { fd, buf, len, ioprio, flags, dest_addr, dest_addr_len } = self;
 
         let mut sqe = sqe_zeroed();
         sqe.opcode = Self::CODE;
@@ -1056,6 +1057,7 @@ opcode! {
         sqe.__bindgen_anon_1.addr2 = dest_addr as _;
         sqe.__bindgen_anon_5.__bindgen_anon_1.addr_len = dest_addr_len as _;
         sqe.len = len;
+        sqe.ioprio = ioprio;
         sqe.__bindgen_anon_3.msg_flags = flags as _;
         Entry(sqe)
     }
@@ -1068,6 +1070,7 @@ opcode! {
         buf: { *mut u8 },
         len: { u32 },
         ;;
+        ioprio: u16 = 0,
         flags: i32 = 0,
         buf_group: u16 = 0
     }
@@ -1075,13 +1078,14 @@ opcode! {
     pub const CODE = sys::IORING_OP_RECV;
 
     pub fn build(self) -> Entry {
-        let Recv { fd, buf, len, flags, buf_group } = self;
+        let Recv { fd, buf, len, ioprio, flags, buf_group } = self;
 
         let mut sqe = sqe_zeroed();
         sqe.opcode = Self::CODE;
         assign_fd!(sqe.fd = fd);
         sqe.__bindgen_anon_2.addr = buf as _;
         sqe.len = len;
+        sqe.ioprio = ioprio;
         sqe.__bindgen_anon_3.msg_flags = flags as _;
         sqe.__bindgen_anon_4.buf_group = buf_group;
         Entry(sqe)


### PR DESCRIPTION
This adds the `ioprio` setter for `Send` and `Recv` opcodes.