### PR TITLE
feat: add `register_ring_fd`/`unregister_ring_fd` methods

### DIFF
--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -81,6 +81,7 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     // register
     tests::register::test_register_files_sparse(&mut ring, &test)?;
+    tests::register::test_register_ring_fd(&mut ring, &test)?;
     tests::register_buffers::test_register_buffers(&mut ring, &test)?;
     tests::register_buffers::test_register_buffers_update(&mut ring, &test)?;
     tests::register_buf_ring::test_register_buf_ring(&mut ring, &test)?;

--- a/io-uring-test/src/tests/register.rs
+++ b/io-uring-test/src/tests/register.rs
@@ -68,3 +68,64 @@ pub fn test_register_files_sparse<S: squeue::EntryMarker, C: cqueue::EntryMarker
 
     Ok(())
 }
+
+pub fn test_register_ring_fd<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    _test: &Test,
+) -> anyhow::Result<()> {
+    println!("test register_ring_fd");
+
+    // register_ring_fd was introduced in kernel 5.18. Skip the test if it is not supported.
+    match ring.submitter().register_ring_fd() {
+        Ok(()) => {}
+        Err(e) if e.raw_os_error() == Some(libc::EINVAL) => {
+            println!("register_ring_fd not supported, skipping");
+            return Ok(());
+        }
+        Err(e) => return Err(anyhow::anyhow!("register_ring_fd failed: {}", e)),
+    }
+
+    // Registering twice should fail.
+    if ring.submitter().register_ring_fd().is_ok() {
+        return Err(anyhow::anyhow!(
+            "register_ring_fd should not have succeeded twice in a row"
+        ));
+    }
+
+    // Submitting now transparently goes through the registered ring index.
+    let nop = opcode::Nop::new().build().user_data(0x42).into();
+    unsafe {
+        ring.submission()
+            .push(&nop)
+            .expect("submission queue is full");
+    }
+    ring.submit_and_wait(1)?;
+    let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
+    assert_eq!(cqes.len(), 1);
+    assert_eq!(cqes[0].user_data(), 0x42);
+    assert_eq!(cqes[0].result(), 0);
+
+    ring.submitter().unregister_ring_fd()?;
+
+    // Unregistering twice should fail.
+    if ring.submitter().unregister_ring_fd().is_ok() {
+        return Err(anyhow::anyhow!(
+            "unregister_ring_fd should not have succeeded twice in a row"
+        ));
+    }
+
+    // Submitting still works after unregistering, now via the raw file descriptor.
+    let nop = opcode::Nop::new().build().user_data(0x43).into();
+    unsafe {
+        ring.submission()
+            .push(&nop)
+            .expect("submission queue is full");
+    }
+    ring.submit_and_wait(1)?;
+    let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
+    assert_eq!(cqes.len(), 1);
+    assert_eq!(cqes[0].user_data(), 0x43);
+    assert_eq!(cqes[0].result(), 0);
+
+    Ok(())
+}

--- a/io-uring-test/src/tests/register.rs
+++ b/io-uring-test/src/tests/register.rs
@@ -71,18 +71,18 @@ pub fn test_register_files_sparse<S: squeue::EntryMarker, C: cqueue::EntryMarker
 
 pub fn test_register_ring_fd<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     ring: &mut IoUring<S, C>,
-    _test: &Test,
+    test: &Test,
 ) -> anyhow::Result<()> {
+    require!(
+        test;
+        is_register_ring_fd_supported(ring)?;
+    );
+
     println!("test register_ring_fd");
 
-    // register_ring_fd was introduced in kernel 5.18. Skip the test if it is not supported.
     let mut submitter = ring.submitter();
     match submitter.register_ring_fd() {
         Ok(()) => {}
-        Err(e) if e.raw_os_error() == Some(libc::EINVAL) => {
-            println!("register_ring_fd not supported, skipping");
-            return Ok(());
-        }
         Err(e) => return Err(anyhow::anyhow!("register_ring_fd failed: {}", e)),
     }
 
@@ -100,6 +100,9 @@ pub fn test_register_ring_fd<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
             ));
         }
     }
+
+    let mut probe = io_uring::Probe::new();
+    submitter.register_probe(&mut probe)?;
 
     let mut other_submitter = ring.submitter();
     match other_submitter.unregister_ring_fd() {
@@ -182,4 +185,19 @@ pub fn test_register_ring_fd<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     assert_eq!(cqes[0].result(), 0);
 
     Ok(())
+}
+
+fn is_register_ring_fd_supported<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+) -> anyhow::Result<bool> {
+    let mut submitter = ring.submitter();
+
+    match submitter.register_ring_fd() {
+        Ok(()) => {
+            submitter.unregister_ring_fd()?;
+            Ok(true)
+        }
+        Err(e) if e.raw_os_error() == Some(libc::EINVAL) => Ok(false),
+        Err(e) => Err(anyhow::anyhow!("register_ring_fd probe failed: {}", e)),
+    }
 }

--- a/io-uring-test/src/tests/register.rs
+++ b/io-uring-test/src/tests/register.rs
@@ -76,7 +76,8 @@ pub fn test_register_ring_fd<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     println!("test register_ring_fd");
 
     // register_ring_fd was introduced in kernel 5.18. Skip the test if it is not supported.
-    match ring.submitter().register_ring_fd() {
+    let mut submitter = ring.submitter();
+    match submitter.register_ring_fd() {
         Ok(()) => {}
         Err(e) if e.raw_os_error() == Some(libc::EINVAL) => {
             println!("register_ring_fd not supported, skipping");
@@ -85,44 +86,97 @@ pub fn test_register_ring_fd<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
         Err(e) => return Err(anyhow::anyhow!("register_ring_fd failed: {}", e)),
     }
 
-    // Registering twice should fail.
-    if ring.submitter().register_ring_fd().is_ok() {
-        return Err(anyhow::anyhow!(
-            "register_ring_fd should not have succeeded twice in a row"
-        ));
+    match submitter.register_ring_fd() {
+        Err(e) if e.raw_os_error() == Some(libc::EEXIST) => {}
+        Ok(()) => {
+            return Err(anyhow::anyhow!(
+                "register_ring_fd should not have succeeded twice on the same submitter"
+            ));
+        }
+        Err(e) => {
+            return Err(anyhow::anyhow!(
+                "register_ring_fd should have failed with EEXIST on the same submitter: {}",
+                e
+            ));
+        }
     }
+
+    let mut other_submitter = ring.submitter();
+    match other_submitter.unregister_ring_fd() {
+        Err(e) if e.raw_os_error() == Some(libc::EINVAL) => {}
+        Ok(()) => {
+            return Err(anyhow::anyhow!(
+                "unregister_ring_fd should be scoped to the registering submitter"
+            ));
+        }
+        Err(e) => {
+            return Err(anyhow::anyhow!(
+                "unregister_ring_fd should have failed with EINVAL on an unregistered submitter: {}",
+                e
+            ));
+        }
+    }
+    other_submitter.register_ring_fd()?;
+    match other_submitter.register_ring_fd() {
+        Err(e) if e.raw_os_error() == Some(libc::EEXIST) => {}
+        Ok(()) => {
+            return Err(anyhow::anyhow!(
+                "register_ring_fd should not have succeeded twice on another submitter"
+            ));
+        }
+        Err(e) => {
+            return Err(anyhow::anyhow!(
+                "register_ring_fd should have failed with EEXIST on another submitter: {}",
+                e
+            ));
+        }
+    }
+    other_submitter.unregister_ring_fd()?;
+
+    submitter.unregister_ring_fd()?;
+
+    let (mut submitter, mut sq, mut cq) = ring.split();
+    submitter.register_ring_fd()?;
 
     // Submitting now transparently goes through the registered ring index.
     let nop = opcode::Nop::new().build().user_data(0x42).into();
     unsafe {
-        ring.submission()
-            .push(&nop)
-            .expect("submission queue is full");
+        sq.push(&nop).expect("submission queue is full");
     }
-    ring.submit_and_wait(1)?;
-    let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
+    sq.sync();
+    submitter.submit_and_wait(1)?;
+    cq.sync();
+    let cqes: Vec<cqueue::Entry> = cq.by_ref().map(Into::into).collect();
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x42);
     assert_eq!(cqes[0].result(), 0);
 
-    ring.submitter().unregister_ring_fd()?;
+    submitter.unregister_ring_fd()?;
 
-    // Unregistering twice should fail.
-    if ring.submitter().unregister_ring_fd().is_ok() {
-        return Err(anyhow::anyhow!(
-            "unregister_ring_fd should not have succeeded twice in a row"
-        ));
+    match submitter.unregister_ring_fd() {
+        Err(e) if e.raw_os_error() == Some(libc::EINVAL) => {}
+        Ok(()) => {
+            return Err(anyhow::anyhow!(
+                "unregister_ring_fd should not have succeeded twice in a row"
+            ));
+        }
+        Err(e) => {
+            return Err(anyhow::anyhow!(
+                "unregister_ring_fd should have failed with EINVAL after unregistering: {}",
+                e
+            ));
+        }
     }
 
     // Submitting still works after unregistering, now via the raw file descriptor.
     let nop = opcode::Nop::new().build().user_data(0x43).into();
     unsafe {
-        ring.submission()
-            .push(&nop)
-            .expect("submission queue is full");
+        sq.push(&nop).expect("submission queue is full");
     }
-    ring.submit_and_wait(1)?;
-    let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
+    sq.sync();
+    submitter.submit_and_wait(1)?;
+    cq.sync();
+    let cqes: Vec<cqueue::Entry> = cq.map(Into::into).collect();
     assert_eq!(cqes.len(), 1);
     assert_eq!(cqes[0].user_data(), 0x43);
     assert_eq!(cqes[0].result(), 0);

--- a/io-uring-test/src/utils.rs
+++ b/io-uring-test/src/utils.rs
@@ -14,7 +14,7 @@ macro_rules! require {
         }
 
         $(
-            cond &= $cond;
+            cond = cond && $cond;
         )*
 
         if !cond {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ pub mod types;
 use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::sync::atomic;
 use std::{cmp, io, mem};
 
 #[cfg(feature = "io_safety")]
@@ -84,6 +85,11 @@ where
     fd: OwnedFd,
     params: Parameters,
     memory: ManuallyDrop<MemoryMap>,
+
+    /// The registered ring fd index used for `io_uring_enter`, or `-1` when no ring fd is
+    /// registered. While set to a valid index (by [`Submitter::register_ring_fd`]), `enter` passes
+    /// it together with `IORING_ENTER_REGISTERED_RING` instead of the raw file descriptor.
+    enter_ring_fd: atomic::AtomicI32,
 }
 
 #[allow(dead_code)]
@@ -217,6 +223,7 @@ impl<S: squeue::EntryMarker, C: cqueue::EntryMarker> IoUring<S, C> {
             fd,
             params: Parameters(p),
             memory: ManuallyDrop::new(mm),
+            enter_ring_fd: atomic::AtomicI32::new(-1),
         })
     }
 
@@ -227,6 +234,7 @@ impl<S: squeue::EntryMarker, C: cqueue::EntryMarker> IoUring<S, C> {
         Submitter::new(
             &self.fd,
             &self.params,
+            &self.enter_ring_fd,
             self.sq.head,
             self.sq.tail,
             self.sq.flags,
@@ -269,6 +277,7 @@ impl<S: squeue::EntryMarker, C: cqueue::EntryMarker> IoUring<S, C> {
         let submit = Submitter::new(
             &self.fd,
             &self.params,
+            &self.enter_ring_fd,
             self.sq.head,
             self.sq.tail,
             self.sq.flags,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,6 @@ pub mod types;
 use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
-use std::sync::atomic;
 use std::{cmp, io, mem};
 
 #[cfg(feature = "io_safety")]
@@ -85,11 +84,6 @@ where
     fd: OwnedFd,
     params: Parameters,
     memory: ManuallyDrop<MemoryMap>,
-
-    /// The registered ring fd index used for `io_uring_enter`, or `-1` when no ring fd is
-    /// registered. While set to a valid index (by [`Submitter::register_ring_fd`]), `enter` passes
-    /// it together with `IORING_ENTER_REGISTERED_RING` instead of the raw file descriptor.
-    enter_ring_fd: atomic::AtomicI32,
 }
 
 #[allow(dead_code)]
@@ -223,7 +217,6 @@ impl<S: squeue::EntryMarker, C: cqueue::EntryMarker> IoUring<S, C> {
             fd,
             params: Parameters(p),
             memory: ManuallyDrop::new(mm),
-            enter_ring_fd: atomic::AtomicI32::new(-1),
         })
     }
 
@@ -234,7 +227,6 @@ impl<S: squeue::EntryMarker, C: cqueue::EntryMarker> IoUring<S, C> {
         Submitter::new(
             &self.fd,
             &self.params,
-            &self.enter_ring_fd,
             self.sq.head,
             self.sq.tail,
             self.sq.flags,
@@ -277,7 +269,6 @@ impl<S: squeue::EntryMarker, C: cqueue::EntryMarker> IoUring<S, C> {
         let submit = Submitter::new(
             &self.fd,
             &self.params,
-            &self.enter_ring_fd,
             self.sq.head,
             self.sq.tail,
             self.sq.flags,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -638,6 +638,10 @@ impl Parameters {
         self.0.features & sys::IORING_FEAT_LINKED_FILE != 0
     }
 
+    pub(crate) fn is_feature_reg_reg_ring(&self) -> bool {
+        self.0.features & sys::IORING_FEAT_REG_REG_RING != 0
+    }
+
     /// Whether the kernel supports `IORING_RECVSEND_BUNDLE`.
     ///
     /// This feature allows sending and recieving multiple buffers as a single bundle. Available

--- a/src/register.rs
+++ b/src/register.rs
@@ -5,12 +5,24 @@ use std::{fmt, io};
 
 use crate::sys;
 
+pub(crate) enum RegisterRing {
+    RawFd(RawFd),
+    RegisteredIndex(i32),
+}
+
 pub(crate) fn execute(
-    fd: RawFd,
+    ring: RegisterRing,
     opcode: libc::c_uint,
     arg: *const libc::c_void,
     len: libc::c_uint,
 ) -> io::Result<i32> {
+    let (fd, opcode) = match ring {
+        RegisterRing::RawFd(fd) => (fd, opcode),
+        RegisterRing::RegisteredIndex(index) => {
+            (index, opcode | sys::IORING_REGISTER_USE_REGISTERED_RING)
+        }
+    };
+
     unsafe { sys::io_uring_register(fd, opcode, arg, len) }
 }
 

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -104,6 +104,26 @@ impl<'a> Submitter<'a> {
         }
     }
 
+    #[inline]
+    fn execute_register(
+        &self,
+        opcode: libc::c_uint,
+        arg: *const libc::c_void,
+        len: libc::c_uint,
+    ) -> io::Result<i32> {
+        let enter_ring_fd = self.enter_ring_fd;
+        let (fd, opcode) = if enter_ring_fd >= 0 && self.params.is_feature_reg_reg_ring() {
+            (
+                enter_ring_fd,
+                opcode | sys::IORING_REGISTER_USE_REGISTERED_RING,
+            )
+        } else {
+            (self.fd.as_raw_fd(), opcode)
+        };
+
+        execute(fd, opcode, arg, len)
+    }
+
     /// Initiate and/or complete asynchronous I/O. This is a low-level wrapper around
     /// `io_uring_enter` - see `man io_uring_enter` (or [its online
     /// version](https://manpages.debian.org/unstable/liburing-dev/io_uring_enter.2.en.html) for
@@ -244,8 +264,7 @@ impl<'a> Submitter<'a> {
     /// be valid until buffers are unregistered or the ring destroyed, otherwise undefined
     /// behaviour may occur.
     pub unsafe fn register_buffers(&self, bufs: &[libc::iovec]) -> io::Result<()> {
-        execute(
-            self.fd.as_raw_fd(),
+        self.execute_register(
             sys::IORING_REGISTER_BUFFERS,
             bufs.as_ptr().cast(),
             bufs.len() as _,
@@ -287,8 +306,7 @@ impl<'a> Submitter<'a> {
             ..Default::default()
         };
 
-        execute(
-            self.fd.as_raw_fd(),
+        self.execute_register(
             sys::IORING_REGISTER_BUFFERS_UPDATE,
             cast_ptr::<sys::io_uring_rsrc_update2>(&rr).cast(),
             std::mem::size_of::<sys::io_uring_rsrc_update2>() as _,
@@ -322,8 +340,7 @@ impl<'a> Submitter<'a> {
             tags: tags.as_ptr() as _,
             ..Default::default()
         };
-        execute(
-            self.fd.as_raw_fd(),
+        self.execute_register(
             sys::IORING_REGISTER_BUFFERS2,
             cast_ptr::<sys::io_uring_rsrc_register>(&rr).cast(),
             std::mem::size_of::<sys::io_uring_rsrc_register>() as _,
@@ -346,8 +363,7 @@ impl<'a> Submitter<'a> {
             flags: sys::IORING_RSRC_REGISTER_SPARSE,
             ..Default::default()
         };
-        execute(
-            self.fd.as_raw_fd(),
+        self.execute_register(
             sys::IORING_REGISTER_BUFFERS2,
             cast_ptr::<sys::io_uring_rsrc_register>(&rr).cast(),
             std::mem::size_of::<sys::io_uring_rsrc_register>() as _,
@@ -368,8 +384,7 @@ impl<'a> Submitter<'a> {
             data: 0,
             tags: 0,
         };
-        execute(
-            self.fd.as_raw_fd(),
+        self.execute_register(
             sys::IORING_REGISTER_FILES2,
             cast_ptr::<sys::io_uring_rsrc_register>(&rr).cast(),
             mem::size_of::<sys::io_uring_rsrc_register>() as _,
@@ -386,8 +401,7 @@ impl<'a> Submitter<'a> {
     /// Note that this will wait for the ring to idle; it will only return once all active requests
     /// are complete. Use [`register_files_update`](Self::register_files_update) to avoid this.
     pub fn register_files(&self, fds: &[RawFd]) -> io::Result<()> {
-        execute(
-            self.fd.as_raw_fd(),
+        self.execute_register(
             sys::IORING_REGISTER_FILES,
             fds.as_ptr().cast(),
             fds.len() as _,
@@ -408,8 +422,7 @@ impl<'a> Submitter<'a> {
             resv: 0,
             fds: fds.as_ptr() as _,
         };
-        let ret = execute(
-            self.fd.as_raw_fd(),
+        let ret = self.execute_register(
             sys::IORING_REGISTER_FILES_UPDATE,
             cast_ptr::<sys::io_uring_files_update>(&fu).cast(),
             fds.len() as _,
@@ -419,8 +432,7 @@ impl<'a> Submitter<'a> {
 
     /// Register an eventfd created by [`eventfd`](libc::eventfd) with the io_uring instance.
     pub fn register_eventfd(&self, eventfd: RawFd) -> io::Result<()> {
-        execute(
-            self.fd.as_raw_fd(),
+        self.execute_register(
             sys::IORING_REGISTER_EVENTFD,
             cast_ptr::<RawFd>(&eventfd).cast(),
             1,
@@ -432,8 +444,7 @@ impl<'a> Submitter<'a> {
     /// only posted for events that complete in an async manner, so requests that complete
     /// immediately will not cause a notification.
     pub fn register_eventfd_async(&self, eventfd: RawFd) -> io::Result<()> {
-        execute(
-            self.fd.as_raw_fd(),
+        self.execute_register(
             sys::IORING_REGISTER_EVENTFD_ASYNC,
             cast_ptr::<RawFd>(&eventfd).cast(),
             1,
@@ -461,8 +472,7 @@ impl<'a> Submitter<'a> {
     /// # }
     /// ```
     pub fn register_probe(&self, probe: &mut Probe) -> io::Result<()> {
-        execute(
-            self.fd.as_raw_fd(),
+        self.execute_register(
             sys::IORING_REGISTER_PROBE,
             probe.as_mut_ptr() as *const _,
             Probe::COUNT as _,
@@ -480,12 +490,7 @@ impl<'a> Submitter<'a> {
     ///
     /// [`Parameters::is_feature_cur_personality`]: crate::Parameters::is_feature_cur_personality
     pub fn register_personality(&self) -> io::Result<u16> {
-        let id = execute(
-            self.fd.as_raw_fd(),
-            sys::IORING_REGISTER_PERSONALITY,
-            ptr::null(),
-            0,
-        )?;
+        let id = self.execute_register(sys::IORING_REGISTER_PERSONALITY, ptr::null(), 0)?;
         Ok(id as u16)
     }
 
@@ -496,13 +501,8 @@ impl<'a> Submitter<'a> {
     ///
     /// Available since Linux 5.1.
     pub fn unregister_buffers(&self) -> io::Result<()> {
-        execute(
-            self.fd.as_raw_fd(),
-            sys::IORING_UNREGISTER_BUFFERS,
-            ptr::null(),
-            0,
-        )
-        .map(drop)
+        self.execute_register(sys::IORING_UNREGISTER_BUFFERS, ptr::null(), 0)
+            .map(drop)
     }
 
     /// Unregister all previously registered files.
@@ -510,30 +510,19 @@ impl<'a> Submitter<'a> {
     /// You do not need to explicitly call this before dropping the [`IoUring`](crate::IoUring), as
     /// it will be cleaned up by the kernel automatically.
     pub fn unregister_files(&self) -> io::Result<()> {
-        execute(
-            self.fd.as_raw_fd(),
-            sys::IORING_UNREGISTER_FILES,
-            ptr::null(),
-            0,
-        )
-        .map(drop)
+        self.execute_register(sys::IORING_UNREGISTER_FILES, ptr::null(), 0)
+            .map(drop)
     }
 
     /// Unregister an eventfd file descriptor to stop notifications.
     pub fn unregister_eventfd(&self) -> io::Result<()> {
-        execute(
-            self.fd.as_raw_fd(),
-            sys::IORING_UNREGISTER_EVENTFD,
-            ptr::null(),
-            0,
-        )
-        .map(drop)
+        self.execute_register(sys::IORING_UNREGISTER_EVENTFD, ptr::null(), 0)
+            .map(drop)
     }
 
     /// Unregister a previously registered personality.
     pub fn unregister_personality(&self, personality: u16) -> io::Result<()> {
-        execute(
-            self.fd.as_raw_fd(),
+        self.execute_register(
             sys::IORING_UNREGISTER_PERSONALITY,
             ptr::null(),
             personality as _,
@@ -546,8 +535,7 @@ impl<'a> Submitter<'a> {
     ///
     /// This can only be called once, to prevent untrusted code from removing restrictions.
     pub fn register_restrictions(&self, res: &mut [Restriction]) -> io::Result<()> {
-        execute(
-            self.fd.as_raw_fd(),
+        self.execute_register(
             sys::IORING_REGISTER_RESTRICTIONS,
             res.as_mut_ptr().cast(),
             res.len() as _,
@@ -558,21 +546,15 @@ impl<'a> Submitter<'a> {
     /// Enable the rings of the io_uring instance if they have been disabled with
     /// [`setup_r_disabled`](crate::Builder::setup_r_disabled).
     pub fn register_enable_rings(&self) -> io::Result<()> {
-        execute(
-            self.fd.as_raw_fd(),
-            sys::IORING_REGISTER_ENABLE_RINGS,
-            ptr::null(),
-            0,
-        )
-        .map(drop)
+        self.execute_register(sys::IORING_REGISTER_ENABLE_RINGS, ptr::null(), 0)
+            .map(drop)
     }
 
     /// Tell io_uring on what CPUs the async workers can run. By default, async workers
     /// created by io_uring will inherit the CPU mask of its parent. This is usually
     /// all the CPUs in the system, unless the parent is being run with a limited set.
     pub fn register_iowq_aff(&self, cpu_set: &libc::cpu_set_t) -> io::Result<()> {
-        execute(
-            self.fd.as_raw_fd(),
+        self.execute_register(
             sys::IORING_REGISTER_IOWQ_AFF,
             cpu_set as *const _ as *const libc::c_void,
             mem::size_of::<libc::cpu_set_t>() as u32,
@@ -582,13 +564,8 @@ impl<'a> Submitter<'a> {
 
     /// Undoes a CPU mask previously set with register_iowq_aff
     pub fn unregister_iowq_aff(&self) -> io::Result<()> {
-        execute(
-            self.fd.as_raw_fd(),
-            sys::IORING_UNREGISTER_IOWQ_AFF,
-            ptr::null(),
-            0,
-        )
-        .map(drop)
+        self.execute_register(sys::IORING_UNREGISTER_IOWQ_AFF, ptr::null(), 0)
+            .map(drop)
     }
 
     /// Get and/or set the limit for number of io_uring worker threads per NUMA
@@ -599,8 +576,7 @@ impl<'a> Submitter<'a> {
     /// on sockets. Passing `0` does not change the current limit. Returns
     /// previous limits on success.
     pub fn register_iowq_max_workers(&self, max: &mut [u32; 2]) -> io::Result<()> {
-        execute(
-            self.fd.as_raw_fd(),
+        self.execute_register(
             sys::IORING_REGISTER_IOWQ_MAX_WORKERS,
             max.as_mut_ptr().cast(),
             max.len() as _,
@@ -619,6 +595,9 @@ impl<'a> Submitter<'a> {
     /// Calling this while a ring fd is already registered on this [`Submitter`] returns an `EEXIST`
     /// error.
     ///
+    /// On kernels with `IORING_FEAT_REG_REG_RING`, registration methods on this [`Submitter`] also
+    /// use the registered ring fd internally.
+    ///
     /// Available since Linux 5.18.
     pub fn register_ring_fd(&mut self) -> io::Result<()> {
         if self.enter_ring_fd >= 0 {
@@ -630,8 +609,7 @@ impl<'a> Submitter<'a> {
             resv: 0,
             data: raw_fd as _,
         };
-        execute(
-            raw_fd,
+        self.execute_register(
             sys::IORING_REGISTER_RING_FDS,
             (&mut up as *mut sys::io_uring_rsrc_update).cast(),
             1,
@@ -642,7 +620,8 @@ impl<'a> Submitter<'a> {
 
     /// Unregister a ring file descriptor previously registered with
     /// [`register_ring_fd`](Self::register_ring_fd). Subsequent [`enter`](Self::enter) calls revert
-    /// to using the raw file descriptor. Returns an `EINVAL` error if no ring fd is registered.
+    /// to using the raw file descriptor, as do subsequent registration calls. Returns an `EINVAL`
+    /// error if no ring fd is registered.
     ///
     /// Available since Linux 5.18.
     pub fn unregister_ring_fd(&mut self) -> io::Result<()> {
@@ -655,8 +634,7 @@ impl<'a> Submitter<'a> {
             resv: 0,
             data: 0,
         };
-        execute(
-            self.fd.as_raw_fd(),
+        self.execute_register(
             sys::IORING_UNREGISTER_RING_FDS,
             cast_ptr::<sys::io_uring_rsrc_update>(&up).cast(),
             1,
@@ -721,8 +699,7 @@ impl<'a> Submitter<'a> {
             flags,
             ..Default::default()
         };
-        execute(
-            self.fd.as_raw_fd(),
+        self.execute_register(
             sys::IORING_REGISTER_PBUF_RING,
             cast_ptr::<sys::io_uring_buf_reg>(&arg).cast(),
             1,
@@ -740,8 +717,7 @@ impl<'a> Submitter<'a> {
             bgid,
             ..Default::default()
         };
-        execute(
-            self.fd.as_raw_fd(),
+        self.execute_register(
             sys::IORING_UNREGISTER_PBUF_RING,
             cast_ptr::<sys::io_uring_buf_reg>(&arg).cast(),
             1,
@@ -795,8 +771,7 @@ impl<'a> Submitter<'a> {
             ..Default::default()
         };
 
-        execute(
-            self.fd.as_raw_fd(),
+        self.execute_register(
             sys::IORING_REGISTER_SYNC_CANCEL,
             cast_ptr::<sys::io_uring_sync_cancel_reg>(&arg).cast(),
             1,
@@ -808,8 +783,7 @@ impl<'a> Submitter<'a> {
     ///
     /// Available since 6.15.
     pub fn register_ifq(&self, reg: &sys::io_uring_zcrx_ifq_reg) -> io::Result<()> {
-        execute(
-            self.fd.as_raw_fd(),
+        self.execute_register(
             sys::IORING_REGISTER_ZCRX_IFQ,
             cast_ptr::<sys::io_uring_zcrx_ifq_reg>(reg) as _,
             1,

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -412,7 +412,8 @@ impl<'a> Submitter<'a> {
             nr,
             ..Default::default()
         };
-        self.execute_register(
+        execute(
+            RegisterRing::RawFd(self.fd.as_raw_fd()),
             sys::IORING_REGISTER_CLONE_BUFFERS,
             cast_ptr::<sys::io_uring_clone_buffers>(&arg).cast(),
             // This opcode takes a single struct; the kernel requires nr_args == 1.
@@ -701,8 +702,13 @@ impl<'a> Submitter<'a> {
     ///
     /// Available since Linux 6.9.
     pub fn register_napi(&self, napi: &mut Napi) -> io::Result<()> {
-        self.execute_register(sys::IORING_REGISTER_NAPI, napi.as_mut_ptr().cast(), 1)
-            .map(drop)
+        execute(
+            RegisterRing::RawFd(self.fd.as_raw_fd()),
+            sys::IORING_REGISTER_NAPI,
+            napi.as_mut_ptr().cast(),
+            1,
+        )
+        .map(drop)
     }
 
     /// Unregister NAPI busy-poll from this ring.
@@ -713,8 +719,13 @@ impl<'a> Submitter<'a> {
     ///
     /// Available since Linux 6.9.
     pub fn unregister_napi(&self, napi: &mut Napi) -> io::Result<()> {
-        self.execute_register(sys::IORING_UNREGISTER_NAPI, napi.as_mut_ptr().cast(), 1)
-            .map(drop)
+        execute(
+            RegisterRing::RawFd(self.fd.as_raw_fd()),
+            sys::IORING_UNREGISTER_NAPI,
+            napi.as_mut_ptr().cast(),
+            1,
+        )
+        .map(drop)
     }
 
     /// Add a NAPI id to this ring's statically tracked busy-poll set.
@@ -751,7 +762,8 @@ impl<'a> Submitter<'a> {
             op_param: napi_id,
             ..Default::default()
         };
-        self.execute_register(
+        execute(
+            RegisterRing::RawFd(self.fd.as_raw_fd()),
             sys::IORING_REGISTER_NAPI,
             (&mut arg as *mut sys::io_uring_napi).cast(),
             1,

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -52,6 +52,7 @@ bitflags!(
 pub struct Submitter<'a> {
     fd: &'a OwnedFd,
     params: &'a Parameters,
+    enter_ring_fd: &'a atomic::AtomicI32,
 
     sq_head: *const atomic::AtomicU32,
     sq_tail: *const atomic::AtomicU32,
@@ -63,6 +64,7 @@ impl<'a> Submitter<'a> {
     pub(crate) const fn new(
         fd: &'a OwnedFd,
         params: &'a Parameters,
+        enter_ring_fd: &'a atomic::AtomicI32,
         sq_head: *const atomic::AtomicU32,
         sq_tail: *const atomic::AtomicU32,
         sq_flags: *const atomic::AtomicU32,
@@ -70,6 +72,7 @@ impl<'a> Submitter<'a> {
         Submitter {
             fd,
             params,
+            enter_ring_fd,
             sq_head,
             sq_tail,
             sq_flags,
@@ -124,15 +127,19 @@ impl<'a> Submitter<'a> {
             .map(|arg| cast_ptr(arg).cast())
             .unwrap_or_else(ptr::null);
         let size = mem::size_of::<T>();
-        sys::io_uring_enter(
-            self.fd.as_raw_fd(),
-            to_submit,
-            min_complete,
-            flag,
-            arg,
-            size,
-        )
-        .map(|res| res as _)
+
+        // If a ring fd has been registered with [`register_ring_fd`](Self::register_ring_fd),
+        // `enter_ring_fd` holds its index (otherwise `-1`); pass it together with
+        // `IORING_ENTER_REGISTERED_RING` instead of the raw file descriptor to avoid the per-call
+        // fd lookup in the kernel.
+        let enter_ring_fd = self.enter_ring_fd.load(atomic::Ordering::Relaxed);
+        let (fd, flag) = if enter_ring_fd >= 0 {
+            (enter_ring_fd, flag | sys::IORING_ENTER_REGISTERED_RING)
+        } else {
+            (self.fd.as_raw_fd(), flag)
+        };
+
+        sys::io_uring_enter(fd, to_submit, min_complete, flag, arg, size).map(|res| res as _)
     }
 
     /// Submit all queued submission queue events to the kernel.
@@ -603,35 +610,49 @@ impl<'a> Submitter<'a> {
     }
 
     /// Register the io_uring instance's own file descriptor with the kernel, so that subsequent
-    /// [`enter`](Self::enter) calls can use [`EnterFlags::REGISTERED_RING`] together with the
-    /// returned index instead of the raw file descriptor. This avoids the per-call file descriptor
-    /// lookup overhead in the kernel.
+    /// [`enter`](Self::enter) calls (including [`submit`](Self::submit) and
+    /// [`submit_and_wait`](Self::submit_and_wait)) automatically pass
+    /// [`EnterFlags::REGISTERED_RING`] together with the registered index instead of the raw file
+    /// descriptor. This avoids the per-call file descriptor lookup overhead in the kernel.
     ///
-    /// Returns the index assigned to the registered ring file descriptor.
+    /// The registration is remembered by the [`IoUring`](crate::IoUring) instance and used
+    /// transparently; call [`unregister_ring_fd`](Self::unregister_ring_fd) to undo it. Calling this
+    /// while a ring fd is already registered returns an `EEXIST` error.
     ///
     /// Available since Linux 5.18.
-    pub fn register_ring_fd(&self) -> io::Result<u32> {
+    pub fn register_ring_fd(&self) -> io::Result<()> {
+        if self.enter_ring_fd.load(atomic::Ordering::Relaxed) >= 0 {
+            return Err(io::Error::from_raw_os_error(libc::EEXIST));
+        }
+        let raw_fd = self.fd.as_raw_fd();
         let mut up = sys::io_uring_rsrc_update {
             offset: u32::MAX,
             resv: 0,
-            data: self.fd.as_raw_fd() as _,
+            data: raw_fd as _,
         };
         execute(
-            self.fd.as_raw_fd(),
+            raw_fd,
             sys::IORING_REGISTER_RING_FDS,
             (&mut up as *mut sys::io_uring_rsrc_update).cast(),
             1,
         )?;
-        Ok(up.offset)
+        self.enter_ring_fd
+            .store(up.offset as i32, atomic::Ordering::Relaxed);
+        Ok(())
     }
 
     /// Unregister a ring file descriptor previously registered with
-    /// [`register_ring_fd`](Self::register_ring_fd). `offset` is the index returned by that call.
+    /// [`register_ring_fd`](Self::register_ring_fd). Subsequent [`enter`](Self::enter) calls revert
+    /// to using the raw file descriptor. Returns an `EINVAL` error if no ring fd is registered.
     ///
     /// Available since Linux 5.18.
-    pub fn unregister_ring_fd(&self, offset: u32) -> io::Result<()> {
+    pub fn unregister_ring_fd(&self) -> io::Result<()> {
+        let offset = self.enter_ring_fd.load(atomic::Ordering::Relaxed);
+        if offset < 0 {
+            return Err(io::Error::from_raw_os_error(libc::EINVAL));
+        }
         let up = sys::io_uring_rsrc_update {
-            offset,
+            offset: offset as u32,
             resv: 0,
             data: 0,
         };
@@ -640,8 +661,9 @@ impl<'a> Submitter<'a> {
             sys::IORING_UNREGISTER_RING_FDS,
             cast_ptr::<sys::io_uring_rsrc_update>(&up).cast(),
             1,
-        )
-        .map(drop)
+        )?;
+        self.enter_ring_fd.store(-1, atomic::Ordering::Relaxed);
+        Ok(())
     }
 
     /// Register buffer ring for provided buffers.

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -2,7 +2,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::atomic;
 use std::{io, mem, ptr};
 
-use crate::register::{execute, Probe};
+use crate::register::{execute, Probe, RegisterRing};
 use crate::sys;
 use crate::types::{CancelBuilder, Timespec};
 use crate::util::{cast_ptr, OwnedFd};
@@ -111,17 +111,17 @@ impl<'a> Submitter<'a> {
         arg: *const libc::c_void,
         len: libc::c_uint,
     ) -> io::Result<i32> {
-        let enter_ring_fd = self.enter_ring_fd;
-        let (fd, opcode) = if enter_ring_fd >= 0 && self.params.is_feature_reg_reg_ring() {
-            (
-                enter_ring_fd,
-                opcode | sys::IORING_REGISTER_USE_REGISTERED_RING,
-            )
-        } else {
-            (self.fd.as_raw_fd(), opcode)
-        };
+        execute(self.register_ring(), opcode, arg, len)
+    }
 
-        execute(fd, opcode, arg, len)
+    #[inline]
+    fn register_ring(&self) -> RegisterRing {
+        let enter_ring_fd = self.enter_ring_fd;
+        if enter_ring_fd >= 0 && self.params.is_feature_reg_reg_ring() {
+            RegisterRing::RegisteredIndex(enter_ring_fd)
+        } else {
+            RegisterRing::RawFd(self.fd.as_raw_fd())
+        }
     }
 
     /// Initiate and/or complete asynchronous I/O. This is a low-level wrapper around

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -52,7 +52,7 @@ bitflags!(
 pub struct Submitter<'a> {
     fd: &'a OwnedFd,
     params: &'a Parameters,
-    enter_ring_fd: &'a atomic::AtomicI32,
+    enter_ring_fd: i32,
 
     sq_head: *const atomic::AtomicU32,
     sq_tail: *const atomic::AtomicU32,
@@ -64,7 +64,6 @@ impl<'a> Submitter<'a> {
     pub(crate) const fn new(
         fd: &'a OwnedFd,
         params: &'a Parameters,
-        enter_ring_fd: &'a atomic::AtomicI32,
         sq_head: *const atomic::AtomicU32,
         sq_tail: *const atomic::AtomicU32,
         sq_flags: *const atomic::AtomicU32,
@@ -72,7 +71,7 @@ impl<'a> Submitter<'a> {
         Submitter {
             fd,
             params,
-            enter_ring_fd,
+            enter_ring_fd: -1,
             sq_head,
             sq_tail,
             sq_flags,
@@ -132,7 +131,7 @@ impl<'a> Submitter<'a> {
         // `enter_ring_fd` holds its index (otherwise `-1`); pass it together with
         // `IORING_ENTER_REGISTERED_RING` instead of the raw file descriptor to avoid the per-call
         // fd lookup in the kernel.
-        let enter_ring_fd = self.enter_ring_fd.load(atomic::Ordering::Relaxed);
+        let enter_ring_fd = self.enter_ring_fd;
         let (fd, flag) = if enter_ring_fd >= 0 {
             (enter_ring_fd, flag | sys::IORING_ENTER_REGISTERED_RING)
         } else {
@@ -615,13 +614,14 @@ impl<'a> Submitter<'a> {
     /// [`EnterFlags::REGISTERED_RING`] together with the registered index instead of the raw file
     /// descriptor. This avoids the per-call file descriptor lookup overhead in the kernel.
     ///
-    /// The registration is remembered by the [`IoUring`](crate::IoUring) instance and used
-    /// transparently; call [`unregister_ring_fd`](Self::unregister_ring_fd) to undo it. Calling this
-    /// while a ring fd is already registered returns an `EEXIST` error.
+    /// The registration is remembered by this [`Submitter`] and used transparently; call
+    /// [`unregister_ring_fd`](Self::unregister_ring_fd) on the same [`Submitter`] to undo it.
+    /// Calling this while a ring fd is already registered on this [`Submitter`] returns an `EEXIST`
+    /// error.
     ///
     /// Available since Linux 5.18.
-    pub fn register_ring_fd(&self) -> io::Result<()> {
-        if self.enter_ring_fd.load(atomic::Ordering::Relaxed) >= 0 {
+    pub fn register_ring_fd(&mut self) -> io::Result<()> {
+        if self.enter_ring_fd >= 0 {
             return Err(io::Error::from_raw_os_error(libc::EEXIST));
         }
         let raw_fd = self.fd.as_raw_fd();
@@ -636,8 +636,7 @@ impl<'a> Submitter<'a> {
             (&mut up as *mut sys::io_uring_rsrc_update).cast(),
             1,
         )?;
-        self.enter_ring_fd
-            .store(up.offset as i32, atomic::Ordering::Relaxed);
+        self.enter_ring_fd = up.offset as i32;
         Ok(())
     }
 
@@ -646,8 +645,8 @@ impl<'a> Submitter<'a> {
     /// to using the raw file descriptor. Returns an `EINVAL` error if no ring fd is registered.
     ///
     /// Available since Linux 5.18.
-    pub fn unregister_ring_fd(&self) -> io::Result<()> {
-        let offset = self.enter_ring_fd.load(atomic::Ordering::Relaxed);
+    pub fn unregister_ring_fd(&mut self) -> io::Result<()> {
+        let offset = self.enter_ring_fd;
         if offset < 0 {
             return Err(io::Error::from_raw_os_error(libc::EINVAL));
         }
@@ -662,7 +661,7 @@ impl<'a> Submitter<'a> {
             cast_ptr::<sys::io_uring_rsrc_update>(&up).cast(),
             1,
         )?;
-        self.enter_ring_fd.store(-1, atomic::Ordering::Relaxed);
+        self.enter_ring_fd = -1;
         Ok(())
     }
 

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -602,6 +602,48 @@ impl<'a> Submitter<'a> {
         .map(drop)
     }
 
+    /// Register the io_uring instance's own file descriptor with the kernel, so that subsequent
+    /// [`enter`](Self::enter) calls can use [`EnterFlags::REGISTERED_RING`] together with the
+    /// returned index instead of the raw file descriptor. This avoids the per-call file descriptor
+    /// lookup overhead in the kernel.
+    ///
+    /// Returns the index assigned to the registered ring file descriptor.
+    ///
+    /// Available since Linux 5.18.
+    pub fn register_ring_fd(&self) -> io::Result<u32> {
+        let mut up = sys::io_uring_rsrc_update {
+            offset: u32::MAX,
+            resv: 0,
+            data: self.fd.as_raw_fd() as _,
+        };
+        execute(
+            self.fd.as_raw_fd(),
+            sys::IORING_REGISTER_RING_FDS,
+            (&mut up as *mut sys::io_uring_rsrc_update).cast(),
+            1,
+        )?;
+        Ok(up.offset)
+    }
+
+    /// Unregister a ring file descriptor previously registered with
+    /// [`register_ring_fd`](Self::register_ring_fd). `offset` is the index returned by that call.
+    ///
+    /// Available since Linux 5.18.
+    pub fn unregister_ring_fd(&self, offset: u32) -> io::Result<()> {
+        let up = sys::io_uring_rsrc_update {
+            offset,
+            resv: 0,
+            data: 0,
+        };
+        execute(
+            self.fd.as_raw_fd(),
+            sys::IORING_UNREGISTER_RING_FDS,
+            cast_ptr::<sys::io_uring_rsrc_update>(&up).cast(),
+            1,
+        )
+        .map(drop)
+    }
+
     /// Register buffer ring for provided buffers.
     ///
     /// Details can be found in the io_uring_register_buf_ring.3 man page.

--- a/src/submit.rs
+++ b/src/submit.rs
@@ -702,13 +702,8 @@ impl<'a> Submitter<'a> {
     ///
     /// Available since Linux 6.9.
     pub fn register_napi(&self, napi: &mut Napi) -> io::Result<()> {
-        execute(
-            RegisterRing::RawFd(self.fd.as_raw_fd()),
-            sys::IORING_REGISTER_NAPI,
-            napi.as_mut_ptr().cast(),
-            1,
-        )
-        .map(drop)
+        self.execute_register(sys::IORING_REGISTER_NAPI, napi.as_mut_ptr().cast(), 1)
+            .map(drop)
     }
 
     /// Unregister NAPI busy-poll from this ring.
@@ -719,13 +714,8 @@ impl<'a> Submitter<'a> {
     ///
     /// Available since Linux 6.9.
     pub fn unregister_napi(&self, napi: &mut Napi) -> io::Result<()> {
-        execute(
-            RegisterRing::RawFd(self.fd.as_raw_fd()),
-            sys::IORING_UNREGISTER_NAPI,
-            napi.as_mut_ptr().cast(),
-            1,
-        )
-        .map(drop)
+        self.execute_register(sys::IORING_UNREGISTER_NAPI, napi.as_mut_ptr().cast(), 1)
+            .map(drop)
     }
 
     /// Add a NAPI id to this ring's statically tracked busy-poll set.
@@ -762,8 +752,7 @@ impl<'a> Submitter<'a> {
             op_param: napi_id,
             ..Default::default()
         };
-        execute(
-            RegisterRing::RawFd(self.fd.as_raw_fd()),
+        self.execute_register(
             sys::IORING_REGISTER_NAPI,
             (&mut arg as *mut sys::io_uring_napi).cast(),
             1,


### PR DESCRIPTION
Hi. Thank you for providing this nice crate. 

I'm using `io-uring` in HPC environment, the `fget()` overhead from `io_uring_enter(2)` comsumes a lot of CPU. 

I tried to eliminate it with `IORING_REGISTER_RING_FDS` but I found this crate didn't expose the API. This PR add `register_ring_fd()` and `unregister_ring_fd()` to make `IORING_REGISTER_RING_FDS` usable. I've followed the file fd register API pattern to add the methods to `Submitter`, which is `!Send` and `!Sync` to avoid cross-thread usage.

## Benchmark

w/o ring fd register.

<img width="1200" height="726" alt="perf-step1b" src="https://github.com/user-attachments/assets/c1166a78-80ee-4035-bf43-1584be1bfe6e" />

w/ ring fd register.

<img width="1200" height="734" alt="perf-step1c" src="https://github.com/user-attachments/assets/1aa56bfa-9e1a-4746-b030-ed26375642f4" />
