### PR TITLE
io-uring-test: fix flaky epoll_wait_race short-read assertion

### DIFF
--- a/io-uring-test/src/tests/epoll.rs
+++ b/io-uring-test/src/tests/epoll.rs
@@ -289,7 +289,12 @@ pub fn test_race<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
         nr: usize,
     ) -> anyhow::Result<()> {
         for rx_idx in events.iter().take(nr) {
-            let mut tmp = [0u8; 16];
+            // The buffer must be a multiple of `DATA.len()`. A size that isn't (such as
+            // the previous 16) can split a write across two reads once the writer gets
+            // ahead and a pipe holds more than one buffer's worth: the read stops mid
+            // `DATA`, leaving a partial chunk that the next level-triggered read observes
+            // as a short read (`len < DATA.len()`), failing the assertion below.
+            let mut tmp = [0u8; DATA.len() * 8];
             // read
             let len = readers[rx_idx.u64 as usize].read(&mut tmp)?;
             // account for possibility of multiple writes


### PR DESCRIPTION
The reader buffer in `prune_read` was `[0u8; 16]`, which is not a multiple of `DATA.len()` (3). When the writer thread gets ahead and a pipe holds more than 16 bytes, a single read stops mid-`DATA`, leaving a partial chunk in the pipe. Level-triggered epoll then re-reports the pipe readable and the following read returns that 2-byte remainder, so `assert!(len >= DATA.len())` fails.

It is timing dependent (the reader must fall ~6 writes behind on a pipe), which is why it only surfaced intermittently on [the latest-kernel CI job](https://github.com/tokio-rs/io-uring/actions/runs/27969949046/job/82773345120). Sizing the buffer to a multiple of `DATA.len()` keeps every read aligned to whole `DATA` chunks, so reads never split a write.