### PR TITLE
Expose user data through queue entry traits

### DIFF
--- a/src/cqueue.rs
+++ b/src/cqueue.rs
@@ -34,6 +34,12 @@ pub struct CompletionQueue<'a, E: EntryMarker = Entry> {
 /// This is implemented for [`Entry`] and [`Entry32`].
 pub trait EntryMarker: Clone + Debug + Into<Entry> + private::Sealed {
     const BUILD_FLAGS: u32;
+
+    /// Get the application-supplied user data.
+    fn user_data(&self) -> u64;
+
+    /// Replace the application-supplied user data.
+    fn set_user_data(&mut self, user_data: u64);
 }
 
 /// A 16-byte completion queue entry (CQE), representing a complete I/O operation.
@@ -49,6 +55,32 @@ pub struct Entry32(pub(crate) Entry, pub(crate) [u64; 2]);
 fn test_entry_sizes() {
     assert_eq!(mem::size_of::<Entry>(), 16);
     assert_eq!(mem::size_of::<Entry32>(), 32);
+}
+
+#[test]
+fn test_user_data() {
+    fn cqe(user_data: u64) -> Entry {
+        Entry(sys::io_uring_cqe {
+            user_data,
+            res: 0,
+            flags: 0,
+            big_cqe: sys::__IncompleteArrayField::new(),
+        })
+    }
+
+    fn replace<E: EntryMarker>(entry: &mut E, user_data: u64) -> u64 {
+        let previous = entry.user_data();
+        entry.set_user_data(user_data);
+        previous
+    }
+
+    let mut entry = cqe(1);
+    assert_eq!(replace(&mut entry, 2), 1);
+    assert_eq!(entry.user_data(), 2);
+
+    let mut entry = Entry32(cqe(3), [0; 2]);
+    assert_eq!(replace(&mut entry, 4), 3);
+    assert_eq!(entry.user_data(), 4);
 }
 
 impl<E: EntryMarker> Inner<E> {
@@ -206,6 +238,12 @@ impl Entry {
         self.0.user_data
     }
 
+    /// Replace the application-supplied user data.
+    #[inline]
+    pub fn set_user_data(&mut self, user_data: u64) {
+        self.0.user_data = user_data;
+    }
+
     /// Metadata related to the operation.
     ///
     /// This is currently used for:
@@ -221,6 +259,16 @@ impl private::Sealed for Entry {}
 
 impl EntryMarker for Entry {
     const BUILD_FLAGS: u32 = 0;
+
+    #[inline]
+    fn user_data(&self) -> u64 {
+        Entry::user_data(self)
+    }
+
+    #[inline]
+    fn set_user_data(&mut self, user_data: u64) {
+        Entry::set_user_data(self, user_data);
+    }
 }
 
 impl Clone for Entry {
@@ -255,6 +303,12 @@ impl Entry32 {
         self.0 .0.user_data
     }
 
+    /// Replace the application-supplied user data.
+    #[inline]
+    pub fn set_user_data(&mut self, user_data: u64) {
+        self.0 .0.user_data = user_data;
+    }
+
     /// Metadata related to the operation.
     ///
     /// This is currently used for:
@@ -276,6 +330,16 @@ impl private::Sealed for Entry32 {}
 
 impl EntryMarker for Entry32 {
     const BUILD_FLAGS: u32 = sys::IORING_SETUP_CQE32;
+
+    #[inline]
+    fn user_data(&self) -> u64 {
+        Entry32::user_data(self)
+    }
+
+    #[inline]
+    fn set_user_data(&mut self, user_data: u64) {
+        Entry32::set_user_data(self, user_data);
+    }
 }
 
 impl From<Entry32> for Entry {

--- a/src/squeue.rs
+++ b/src/squeue.rs
@@ -33,6 +33,12 @@ pub struct SubmissionQueue<'a, E: EntryMarker = Entry> {
 /// This is implemented for [`Entry`] and [`Entry128`].
 pub trait EntryMarker: Clone + Debug + From<Entry> + private::Sealed {
     const BUILD_FLAGS: u32;
+
+    /// Set the application-supplied user data.
+    fn set_user_data(&mut self, user_data: u64);
+
+    /// Get the application-supplied user data.
+    fn get_user_data(&self) -> u64;
 }
 
 /// A 64-byte submission queue entry (SQE), representing a request for an I/O operation.
@@ -85,6 +91,23 @@ pub struct Entry128(pub(crate) Entry, pub(crate) [u8; 64]);
 fn test_entry_sizes() {
     assert_eq!(mem::size_of::<Entry>(), 64);
     assert_eq!(mem::size_of::<Entry128>(), 128);
+}
+
+#[test]
+fn test_user_data() {
+    fn replace<E: EntryMarker>(entry: &mut E, user_data: u64) -> u64 {
+        let previous = entry.get_user_data();
+        entry.set_user_data(user_data);
+        previous
+    }
+
+    let mut entry = crate::opcode::Nop::new().build().user_data(1);
+    assert_eq!(replace(&mut entry, 2), 1);
+    assert_eq!(entry.get_user_data(), 2);
+
+    let mut entry = Entry128::from(crate::opcode::Nop::new().build().user_data(3));
+    assert_eq!(replace(&mut entry, 4), 3);
+    assert_eq!(entry.get_user_data(), 4);
 }
 
 bitflags! {
@@ -408,6 +431,16 @@ impl private::Sealed for Entry {}
 
 impl EntryMarker for Entry {
     const BUILD_FLAGS: u32 = 0;
+
+    #[inline]
+    fn set_user_data(&mut self, user_data: u64) {
+        Entry::set_user_data(self, user_data);
+    }
+
+    #[inline]
+    fn get_user_data(&self) -> u64 {
+        Entry::get_user_data(self)
+    }
 }
 
 impl Clone for Entry {
@@ -457,6 +490,12 @@ impl Entry128 {
         self.0 .0.user_data = user_data;
     }
 
+    /// Get the previously application-supplied user data.
+    #[inline]
+    pub fn get_user_data(&self) -> u64 {
+        self.0 .0.user_data
+    }
+
     /// Set the personality of this event. You can obtain a personality using
     /// [`Submitter::register_personality`](crate::Submitter::register_personality).
     #[inline]
@@ -476,6 +515,16 @@ impl private::Sealed for Entry128 {}
 
 impl EntryMarker for Entry128 {
     const BUILD_FLAGS: u32 = sys::IORING_SETUP_SQE128;
+
+    #[inline]
+    fn set_user_data(&mut self, user_data: u64) {
+        Entry128::set_user_data(self, user_data);
+    }
+
+    #[inline]
+    fn get_user_data(&self) -> u64 {
+        Entry128::get_user_data(self)
+    }
 }
 
 impl From<Entry> for Entry128 {


### PR DESCRIPTION
Runtimes (e.g., [my nosv package](https://github.com/Orkking2/nosv)) wrapping io-uring may replace an SQE's application-supplied `user_data` with an internal token used to associate completions with runtime state. To preserve the public API's behavior, the runtime must be able to save the original value and restore it on the CQE before returning the completion to the application.

This change:

- exposes user-data access through `squeue::EntryMarker`
- adds the missing `Entry128::get_user_data`
- exposes user-data access and replacement through `cqueue::EntryMarker`
- adds mutable CQE setters for `Entry` and `Entry32`
- tests the save/replace/restore behavior for both entry widths

Validation:

- `cargo test --workspace`
- `cargo clippy -p io-uring --lib`
- formatting check