### PR TITLE
Expose whether the completion queue has entries pending

### DIFF
--- a/io-uring-test/src/main.rs
+++ b/io-uring-test/src/main.rs
@@ -73,6 +73,7 @@ fn test<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
     tests::queue::test_nop(&mut ring, &test)?;
     tests::queue::test_setup_no_sqarray(&mut ring, &test)?;
     tests::queue::test_queue_split(&mut ring, &test)?;
+    tests::queue::test_completion_status(&mut ring, &test)?;
     tests::queue::test_debug_print(&mut ring, &test)?;
     tests::queue::test_msg_ring_data(&mut ring, &test)?;
     tests::queue::test_msg_ring_send_fd(&mut ring, &test)?;

--- a/io-uring-test/src/tests/queue.rs
+++ b/io-uring-test/src/tests/queue.rs
@@ -341,3 +341,38 @@ pub fn test_msg_ring_send_fd<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
 
     Ok(())
 }
+
+pub fn test_completion_status<S: squeue::EntryMarker, C: cqueue::EntryMarker>(
+    ring: &mut IoUring<S, C>,
+    test: &Test,
+) -> anyhow::Result<()> {
+    require! {
+        test;
+    }
+
+    println!("test completion_status");
+
+    // SAFETY: the status is dropped well before `ring` is.
+    let status = unsafe { ring.completion().status() };
+
+    assert!(status.is_empty());
+
+    let nop_e = opcode::Nop::new().build().user_data(0x43).into();
+    unsafe {
+        ring.submission().push(&nop_e).expect("queue is full");
+    }
+    ring.submit_and_wait(1)?;
+
+    // The status observes the kernel's tail directly, so it reports the
+    // completion without the queue having been synchronized.
+    assert!(!status.is_empty());
+
+    let cqes: Vec<cqueue::Entry> = ring.completion().map(Into::into).collect();
+    assert_eq!(cqes.len(), 1);
+    assert_eq!(cqes[0].user_data(), 0x43);
+
+    // ... and consuming it moves the head back level with the tail.
+    assert!(status.is_empty());
+
+    Ok(())
+}

--- a/src/cqueue.rs
+++ b/src/cqueue.rs
@@ -29,6 +29,52 @@ pub struct CompletionQueue<'a, E: EntryMarker = Entry> {
     queue: &'a Inner<E>,
 }
 
+/// A read-only view of whether the completion queue has entries pending.
+///
+/// Obtained from [`CompletionQueue::status`]. Unlike the queue itself this
+/// borrows nothing, so it can be captured once at startup and consulted from
+/// anywhere afterwards. The check costs two loads, with no system call, no
+/// locking, and no access to the ring — which is what a thread-per-core runtime
+/// needs on its preemption check, where reaching the queue would cost more than
+/// the comparison does.
+///
+/// # Staleness
+///
+/// The answer is stale as soon as it is returned: the kernel may post a
+/// completion immediately after the load. This is inherent — any check that
+/// does not enter the kernel is a snapshot — and it makes this suitable for
+/// hints such as "should I stop what I am doing and poll?", where being one
+/// iteration late costs nothing. It is not a synchronization primitive, and
+/// [`CompletionQueue::is_empty`] carries exactly the same caveat.
+pub struct CompletionStatus {
+    head: *const atomic::AtomicU32,
+    tail: *const atomic::AtomicU32,
+}
+
+impl CompletionStatus {
+    /// Returns `true` if the kernel has posted no completions beyond those
+    /// already consumed.
+    ///
+    /// See the note on staleness in the type documentation.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        // SAFETY: both pointers are valid for the life of the ring, per the
+        // contract on `CompletionQueue::status`, and are only read here. The
+        // head is advanced solely by this library from the owning thread, so a
+        // non-atomic load is sound; the tail is written by the kernel, so it
+        // needs `Acquire` to order against the entries it publishes.
+        unsafe { unsync_load(self.head) == (*self.tail).load(atomic::Ordering::Acquire) }
+    }
+}
+
+impl Debug for CompletionStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CompletionStatus")
+            .field("is_empty", &self.is_empty())
+            .finish()
+    }
+}
+
 /// A completion queue entry (CQE), representing a complete I/O operation.
 ///
 /// This is implemented for [`Entry`] and [`Entry32`].
@@ -89,6 +135,21 @@ impl<E: EntryMarker> Inner<E> {
 }
 
 impl<E: EntryMarker> CompletionQueue<'_, E> {
+    /// Returns a [`CompletionStatus`], with which a caller can observe that the
+    /// kernel has posted completions without borrowing this queue.
+    ///
+    /// # Safety
+    ///
+    /// The returned value borrows nothing, and so must not outlive the
+    /// [`IoUring`](crate::IoUring) this queue came from.
+    #[inline]
+    pub unsafe fn status(&self) -> CompletionStatus {
+        CompletionStatus {
+            head: self.queue.head,
+            tail: self.queue.tail,
+        }
+    }
+
     /// Synchronize this type with the real completion queue.
     ///
     /// This will flush any entries consumed in this iterator and will make available new entries

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ use std::{cmp, io, mem};
 #[cfg(feature = "io_safety")]
 use std::os::unix::io::{AsFd, BorrowedFd};
 
-pub use cqueue::CompletionQueue;
+pub use cqueue::{CompletionQueue, CompletionStatus};
 pub use register::Probe;
 pub use squeue::SubmissionQueue;
 pub use submit::EnterFlags;


### PR DESCRIPTION
## Motivation

A thread-per-core runtime needs to know whether the kernel has posted a completion **on its hot path**, without entering the kernel, taking a lock, or borrowing the queue.

Concretely, in [glommio](https://github.com/glommio/glommio) this check runs on every scheduler iteration and every cooperative yield point, from arbitrary depth inside task execution — including from user code. The ring itself is behind a `RefCell` and may already be borrowed at that moment, so **reaching the queue costs far more than the comparison does**.

Nothing on the current public surface allows it:

- `CompletionQueue` keeps `head` and `tail` private, exposing only `sync`, `overflow`, `eventfd_disabled`, `capacity`, `is_empty`, `is_full`, `fill` and iteration — all of which require the borrow.
- They can't be reconstructed from outside either: `IoUring::params()` returns a `Parameters` whose public API is six `is_*` predicates, so `cq_off` isn't reachable.

glommio maintains a vendored copy of the abandoned `iou`/`uring-sys` crates partly because of this. This is what lets that copy — ~3,000 lines and ~100 `unsafe` occurrences — be deleted in favour of this crate.

## What this adds

```rust
/// Obtained from `CompletionQueue::status`. Borrows nothing, so it can be
/// captured once at startup and consulted from anywhere afterwards.
pub struct CompletionStatus { /* head, tail */ }

impl CompletionStatus {
    pub fn is_empty(&self) -> bool;
}

impl<E: EntryMarker> CompletionQueue<'_, E> {
    /// # Safety
    /// The returned value must not outlive the ring.
    pub unsafe fn status(&self) -> CompletionStatus;
}
```

The `unsafe` sits at a single construction site at startup instead of on a path executed millions of times a second. On the consumer side the check becomes `!self.status.is_empty()`, with no `unsafe` at all.

**Staleness is documented on the type.** The answer is stale as soon as it is returned — the kernel may post a completion immediately after the load. That is inherent to any check which does not enter the kernel, and it is worth stating plainly because a safe-looking `is_empty()` hides it more effectively than raw pointers would. It is right for hints such as "should I stop and poll?", where being one iteration late costs nothing; it is not a synchronization primitive. The existing `CompletionQueue::is_empty` carries the same caveat.

## Scope

One method, one small type, one test. No behaviour change, no new state, nothing else touched. `io-uring-test` passes across all four ring configurations, and the new test covers empty, after a completion is posted, and after it is consumed.

Naming is yours to pick — `status()`/`is_empty()` mirrors the existing `CompletionQueue::is_empty`, but `need_preempt`, `has_completions` or `is_ready` are all fine by me, as is hanging it off `IoUring` directly if reaching through `completion()` is awkward.

*(Earlier revisions of this PR exposed the raw head/tail pointers instead; reworked into this shape at @quininer's suggestion.)*
